### PR TITLE
Download as file

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,5 @@
 class ApplicationController < ActionController::API
   include Concerns::ErrorHandling
-  include Concerns::JWTAuthentication
 
   before_action :enforce_json_only
 

--- a/app/controllers/concerns/jwt_authentication.rb
+++ b/app/controllers/concerns/jwt_authentication.rb
@@ -54,7 +54,7 @@ module Concerns
         end
 
         if params[:payload]
-          unless payload['checksum'] == Digest::SHA256.hexdigest(Base64.strict_decode64(params[:payload]))
+          unless payload['checksum'] == Digest::SHA256.hexdigest(Base64.urlsafe_decode64(params[:payload]))
             raise Exceptions::ChecksumMismatchError.new
           end
         else

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -1,9 +1,9 @@
 class DownloadsController < ApplicationController
-  before_action :check_download_params, only: [:show]
+  before_action :check_download_params
 
   def show
     if downloader.exists?
-      render json: { file: downloader.encoded_contents }, status: 200
+      send_data downloader.contents, status: 200
       downloader.purge_from_destination!
     else
       render json: { code: 404, name: 'not-found' }, status: 404

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -15,14 +15,8 @@ class DownloadsController < ApplicationController
   private
 
   def check_download_params
-    if params[:payload].blank?
-      return render json: { code: 400, name: 'invalid.payload-missing' }, status: 400
-    end
-
-    params.merge!(JSON.parse(Base64.urlsafe_decode64(params[:payload])).select{|k,_| %w{ encrypted_user_id_and_token }.include?(k)})
-
-    if params[:encrypted_user_id_and_token].blank?
-      return render json: { code: 400, name: 'invalid.payload-encrypted-user-id-and-token-missing' }, status: 400
+    if request.headers['x-encrypted-user-id-and-token'].blank?
+      return render json: { code: 400, name: 'invalid.header-encrypted-user-id-and-token-missing' }, status: 400
     end
   end
 
@@ -43,7 +37,7 @@ class DownloadsController < ApplicationController
                             service_slug: params[:service_slug],
                             file_fingerprint: file_fingerprint,
                             days_to_live: days_to_live,
-                            cipher_key: Digest::MD5.hexdigest(params[:encrypted_user_id_and_token])).call
+                            cipher_key: Digest::MD5.hexdigest(request.headers['x-encrypted-user-id-and-token'])).call
   end
 
   def error_large_file(size)

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -19,7 +19,7 @@ class DownloadsController < ApplicationController
       return render json: { code: 400, name: 'invalid.payload-missing' }, status: 400
     end
 
-    params.merge!(JSON.parse(Base64.strict_decode64(params[:payload])).select{|k,_| %w{ encrypted_user_id_and_token }.include?(k)})
+    params.merge!(JSON.parse(Base64.urlsafe_decode64(params[:payload])).select{|k,_| %w{ encrypted_user_id_and_token }.include?(k)})
 
     if params[:encrypted_user_id_and_token].blank?
       return render json: { code: 400, name: 'invalid.payload-encrypted-user-id-and-token-missing' }, status: 400

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -1,4 +1,6 @@
 class UploadsController < ApplicationController
+  include Concerns::JWTAuthentication
+
   before_action :check_upload_params, only: [:create]
 
   def create

--- a/app/services/storage/disk/downloader.rb
+++ b/app/services/storage/disk/downloader.rb
@@ -8,10 +8,6 @@ module Storage
         @key = key
       end
 
-      def download
-        FileUtils.cp(path, file.path)
-      end
-
       def exists?
         File.exist?(path)
       end
@@ -27,14 +23,18 @@ module Storage
         @file ||= Tempfile.new(filename)
       end
 
-      def encoded_contents
+      def contents
         download
-        Base64.strict_encode64(file.read)
+        file.read
       end
 
       private
 
       attr_accessor :key
+
+      def download
+        FileUtils.cp(path, file.path)
+      end
 
       def path
         Rails.root.join('tmp/files', key)

--- a/app/services/storage/s3/downloader.rb
+++ b/app/services/storage/s3/downloader.rb
@@ -20,9 +20,9 @@ module Storage
         temp_file.unlink
       end
 
-      def encoded_contents
+      def contents
         download
-        Base64.strict_encode64(temp_file.read)
+        temp_file.read
       end
 
       private

--- a/config/initializers/configure_bucket_lifecycle.rb
+++ b/config/initializers/configure_bucket_lifecycle.rb
@@ -1,21 +1,23 @@
-if ENV['AWS_ACCESS_KEY_ID'] &&
-   ENV['AWS_SECRET_ACCESS_KEY'] &&
-   ENV['AWS_REGION'] &&
-   ENV['AWS_S3_BUCKET_NAME']
-  client = Aws::S3::Client.new
-
-  client.put_bucket_lifecycle_configuration({
-    bucket: ENV['AWS_S3_BUCKET_NAME'],
-    lifecycle_configuration: {
-      rules: [{
-        expiration: { days: 29 },
-        id: '28d',
-        filter: { prefix: '28d/' },
-        status: 'Enabled',
-        abort_incomplete_multipart_upload: {
-          days_after_initiation: 29 }
-        }
-      ]
-    }
-  })
-end
+# Not possible until correct permission applied to credentials
+#
+# if ENV['AWS_ACCESS_KEY_ID'] &&
+#    ENV['AWS_SECRET_ACCESS_KEY'] &&
+#    ENV['AWS_REGION'] &&
+#    ENV['AWS_S3_BUCKET_NAME']
+#   client = Aws::S3::Client.new
+#
+#   client.put_bucket_lifecycle_configuration({
+#     bucket: ENV['AWS_S3_BUCKET_NAME'],
+#     lifecycle_configuration: {
+#       rules: [{
+#         expiration: { days: 29 },
+#         id: '28d',
+#         filter: { prefix: '28d/' },
+#         status: 'Enabled',
+#         abort_incomplete_multipart_upload: {
+#           days_after_initiation: 29 }
+#         }
+#       ]
+#     }
+#   })
+# end

--- a/deploy/fb-user-filestore-chart/templates/network_policy.yaml
+++ b/deploy/fb-user-filestore-chart/templates/network_policy.yaml
@@ -26,6 +26,13 @@ spec:
     ports:
     - protocol: TCP
       port: 3000
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: submitter-workers-{{ .Values.environmentName }}
+    ports:
+    - protocol: TCP
+      port: 3000
   egress:
   - to:
     - ipBlock:

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe DownloadsController, type: :controller do
   before :each do
-    allow_any_instance_of(ApplicationController).to receive(:verify_token!)
     allow(ServiceTokenService).to receive(:get).and_return('service-token')
   end
 

--- a/spec/controllers/uploads_controller_spec.rb
+++ b/spec/controllers/uploads_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe UploadsController, type: :controller do
   before :each do
-    allow_any_instance_of(ApplicationController).to receive(:verify_token!)
+    allow_any_instance_of(UploadsController).to receive(:verify_token!)
     allow(ServiceTokenService).to receive(:get).and_return('service-token')
   end
 

--- a/spec/requests/file_download_spec.rb
+++ b/spec/requests/file_download_spec.rb
@@ -7,27 +7,8 @@ RSpec.describe 'file download', type: :request do
     example.run
   end
 
-  let(:payload) do
-    {
-      iat: Time.now.to_i,
-      checksum: Digest::SHA256.hexdigest(query_string_payload.to_json)
-    }
-  end
-
   let(:headers) do
-    { "X-Access-Token" => JWT.encode(payload, 'service-token', 'HS256') }
-  end
-
-  let(:query_string_payload) do
-    {
-      encrypted_user_id_and_token: '12345678901234567890123456789012'
-    }
-  end
-
-  # Buffer.from(JSON.stringify(payload)).toString('Base64')
-  let(:payload_query_string) do
-    json = query_string_payload.to_json
-    base64 = Base64.strict_encode64(json)
+    { "X-Encrypted-User-Id-And-Token" => '12345678901234567890123456789012' }
   end
 
   before :each do
@@ -37,7 +18,7 @@ RSpec.describe 'file download', type: :request do
 
   describe 'GET /service/{service_slug}/user/{user_id}/{fingerprint}' do
     let(:do_get!) do
-      get "/service/service-slug/user/user-id/28d-fingerprint?payload=#{payload_query_string}", headers: headers
+      get "/service/service-slug/user/user-id/28d-fingerprint", headers: headers
     end
 
     context 'when file does exist' do

--- a/spec/requests/file_download_spec.rb
+++ b/spec/requests/file_download_spec.rb
@@ -52,10 +52,9 @@ RSpec.describe 'file download', type: :request do
         expect(response).to be_successful
       end
 
-      it 'returns correct json' do
+      it 'returns file' do
         do_get!
-        hash = JSON.parse(response.body)
-        expect(hash['file']).to eql(Base64.strict_encode64('Hello World'))
+        expect(response.body).to eql('Hello World')
       end
 
       it 'removes the temporary file' do
@@ -81,9 +80,9 @@ RSpec.describe 'file download', type: :request do
 
     context 'when there is a problem' do
       it 'returns 503' do
-        downloader = double('downloader', exists?: true, encoded_contents: '')
+        downloader = double('downloader', exists?: true)
         allow(Storage::Disk::Downloader).to receive(:new).and_return(downloader)
-        allow(downloader).to receive(:encoded_contents).and_raise(StandardError.new)
+        allow(downloader).to receive(:contents).and_raise(StandardError.new)
 
         do_get!
 

--- a/spec/requests/file_upload_spec.rb
+++ b/spec/requests/file_upload_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'FileUpload API', type: :request do
   end
 
   before :each do
-    allow_any_instance_of(ApplicationController).to receive(:verify_token!)
+    allow_any_instance_of(UploadsController).to receive(:verify_token!)
     allow(ServiceTokenService).to receive(:get).with('service-slug')
                                                .and_return('service-token')
   end

--- a/spec/requests/user_file_spec.rb
+++ b/spec/requests/user_file_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'user filestore API', type: :request do
 
       context 'with a valid token' do
         before do
-          allow_any_instance_of(ApplicationController).to receive(:verify_token!)
+          allow_any_instance_of(UploadsController).to receive(:verify_token!)
         end
       end
     end
@@ -28,7 +28,7 @@ RSpec.describe 'user filestore API', type: :request do
   describe 'request error messages' do
     context 'exception TokenNotValidError raised' do
       before do
-        allow_any_instance_of(ApplicationController).to receive(:verify_token!).and_raise(Exceptions::TokenNotValidError)
+        allow_any_instance_of(UploadsController).to receive(:verify_token!).and_raise(Exceptions::TokenNotValidError)
         post "/service/#{service_slug}/user/#{user_identifier}"
       end
 
@@ -43,7 +43,7 @@ RSpec.describe 'user filestore API', type: :request do
 
     context 'exception TokenNotPresentError raised' do
       before do
-        allow_any_instance_of(ApplicationController).to receive(:verify_token!).and_raise(Exceptions::TokenNotPresentError)
+        allow_any_instance_of(UploadsController).to receive(:verify_token!).and_raise(Exceptions::TokenNotPresentError)
         post "/service/#{service_slug}/user/#{user_identifier}"
       end
 
@@ -58,7 +58,7 @@ RSpec.describe 'user filestore API', type: :request do
 
     context 'exception InternalServerError raised' do
       before do
-        allow_any_instance_of(ApplicationController).to receive(:verify_token!).and_raise(StandardError)
+        allow_any_instance_of(UploadsController).to receive(:verify_token!).and_raise(StandardError)
         post "/service/#{service_slug}/user/#{user_identifier}"
       end
       it 'returns a 500 status' do

--- a/spec/services/storage/disk/downloader_spec.rb
+++ b/spec/services/storage/disk/downloader_spec.rb
@@ -12,24 +12,6 @@ RSpec.describe Storage::Disk::Downloader do
     example.run
   end
 
-  describe '#download' do
-    before :each do
-      uploader.upload
-    end
-
-    describe do
-      it 'downloads file from s3' do
-        subject.download
-
-        downloaded_path = subject.send(:file).path
-
-        contents = File.open(downloaded_path).read
-
-        expect(contents).to eql("lorem ipsum\n")
-      end
-    end
-  end
-
   describe '#exists?' do
     context 'when the file doesnt exist' do
       it 'returns false' do
@@ -45,6 +27,23 @@ RSpec.describe Storage::Disk::Downloader do
       it 'returns truthy' do
         expect(subject.exists?).to be_truthy
       end
+    end
+  end
+
+  describe '#contents' do
+    before :each do
+      uploader.upload
+    end
+
+    describe do
+      it 'contains correct contents' do
+        expect(subject.contents).to eql("lorem ipsum\n")
+      end
+    end
+
+    after :each do
+      subject.purge_from_source!
+      subject.purge_from_destination!
     end
   end
 end

--- a/spec/services/storage/s3/downloader_spec.rb
+++ b/spec/services/storage/s3/downloader_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Storage::S3::Downloader do
   let(:path) { file_fixture('lorem_ipsum.txt') }
   let(:key) { '28d/service-slug/download-fingerprint' }
 
-  describe '#encoded_contents' do
+  describe '#contents' do
     before :each do
       uploader.upload
     end
@@ -31,8 +31,8 @@ RSpec.describe Storage::S3::Downloader do
         }
       end
 
-      it 'returns encoded file contents' do
-        expect(subject.encoded_contents).to eql(Base64.strict_encode64("lorem ipsum\n"))
+      it 'contains correct contents' do
+        expect(subject.contents).to eql("lorem ipsum\n")
       end
     end
 

--- a/spec/support/jwt_authenticated_method.rb
+++ b/spec/support/jwt_authenticated_method.rb
@@ -7,7 +7,7 @@ RSpec.shared_examples 'a JWT-authenticated method' do |method, url, payload|
   let(:service_token) { 'ServiceToken' }
 
   before do
-    allow_any_instance_of(ApplicationController).to receive(:get_service_token).and_return(service_token)
+    allow_any_instance_of(UploadsController).to receive(:get_service_token).and_return(service_token)
     send(method, url, headers: headers)
   end
 


### PR DESCRIPTION
- No longer wrapping file download in json nor encoding
- Still need to implement chunked download which was not possible before
- Use URL safe decoding for payload to prevent issues. It satisfies RFC 4648 and can exclude padding
- removed jwt from download endpoint. networking rules to be put in place instead