### PR TITLE
add sentry to capture exceptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'rails', '~> 5.2.1', '>= 5.2.1.1'
 gem 'puma', '~> 3.11'
 gem 'aws-sdk-s3', '~> 1'
 gem 'jwt'
+gem 'sentry-raven'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,8 @@ GEM
       dotenv (= 2.7.1)
       railties (>= 3.2, < 6.1)
     erubi (1.8.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
     ffi (1.10.0)
     formatador (0.2.5)
     globalid (0.4.2)
@@ -108,6 +110,7 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
+    multipart-post (2.1.1)
     nenv (0.3.0)
     nio4r (2.3.1)
     nokogiri (1.10.1)
@@ -172,6 +175,8 @@ GEM
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
     ruby_dep (1.5.0)
+    sentry-raven (2.9.0)
+      faraday (>= 0.7.6, < 1.0)
     shellany (0.0.1)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
@@ -201,6 +206,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 5.2.1, >= 5.2.1.1)
   rspec-rails (~> 3.8)
+  sentry-raven
   timecop
   tzinfo-data
 

--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -4,6 +4,8 @@ module Concerns
 
     included do
       rescue_from StandardError do |e|
+        Raven.capture_exception(e)
+
         args = { message: e.message }
         unless Rails.env.production?
           args.merge!(

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,4 @@
+Raven.configure do |config|
+  config.dsn = ENV['SENTRY_DSN']
+  config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+end

--- a/deploy/fb-user-filestore-chart/templates/deployment.yaml
+++ b/deploy/fb-user-filestore-chart/templates/deployment.yaml
@@ -62,3 +62,8 @@ spec:
               secretKeyRef:
                 name: fb-user-filestore-api-secrets-{{ .Values.environmentName }}
                 key: encryption_key
+          - name: SENTRY_DSN
+            valueFrom:
+              secretKeyRef:
+                name: fb-user-filestore-api-secrets-{{ .Values.environmentName }}
+                key: sentry_dsn

--- a/spec/controllers/concerns/error_handling_spec.rb
+++ b/spec/controllers/concerns/error_handling_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationController do
+  context 'when there is an error' do
+    controller do
+      include Concerns::ErrorHandling
+
+      def index
+        raise :foo
+      end
+    end
+
+    it 'calls raven (sentry) with exception' do
+      expect(Raven).to receive(:capture_exception)
+      get :index
+    end
+  end
+
+  context 'when there is no error' do
+    controller do
+      include Concerns::ErrorHandling
+
+      def index
+      end
+    end
+
+    it 'does not call raven (sentry)' do
+      expect(Raven).to_not receive(:capture_exception)
+      get :index
+    end
+  end
+end


### PR DESCRIPTION
I've added 3 projects to sentry for the different environments: `test`, `integration`, `live`