### PR TITLE
Add Kubernetes readiness probe

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,0 +1,5 @@
+class HealthController < ActionController::API
+  def show
+    render plain: 'healthy'
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get '/health', to: 'health#show'
   get '/service/:service_slug/user/:user_id/:fingerprint_with_prefix', to: 'downloads#show'
   post '/service/:service_slug/user/:user_id', to: 'uploads#create'
 end

--- a/deploy/fb-user-filestore-chart/templates/deployment.yaml
+++ b/deploy/fb-user-filestore-chart/templates/deployment.yaml
@@ -21,6 +21,13 @@ spec:
         imagePullPolicy: Always
         ports:
           - containerPort: 3000
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 3000
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
         # non-secret env vars
         # defined in config_map.yaml
         envFrom:

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe 'health', type: :request do
+  describe 'GET /health' do
+    it 'responds with healthy' do
+      get '/health'
+      expect(response.status).to eq(200)
+      expect(response.body).to eq('healthy')
+    end
+  end
+end


### PR DESCRIPTION
Even though we are doing rolling deploys, it seems that traffic is being served
to the pods before Rails has booted. So this is still resulting in downtime.

By exposing an endpoint for the readiness probe to test, we can ensure that the application
will be ready to serve traffic by the time it is registered with the load balancer.