### PR TITLE
Expose and endpoint to request a public version of a file

### DIFF
--- a/app/controllers/public_files_controller.rb
+++ b/app/controllers/public_files_controller.rb
@@ -1,0 +1,6 @@
+class PublicFilesController < ApplicationController
+
+  def create
+    render json: {}, status: 201
+  end
+end

--- a/app/controllers/public_files_controller.rb
+++ b/app/controllers/public_files_controller.rb
@@ -1,6 +1,15 @@
 class PublicFilesController < ApplicationController
+  before_action :check_params, only: [:create]
 
   def create
     render json: {}, status: 201
+  end
+
+  private
+
+  def check_params
+    if params[:url].blank?
+      return render json: { code: 400, name: 'invalid.url-missing' }, status: 400
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   get '/health', to: 'health#show'
   get '/service/:service_slug/user/:user_id/:fingerprint_with_prefix', to: 'downloads#show'
   post '/service/:service_slug/user/:user_id', to: 'uploads#create'
+  post '/service/:service_slug/user/:user_id/public-file', to: 'public_files#create'
 end

--- a/spec/requests/public_file_spec.rb
+++ b/spec/requests/public_file_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe 'POST /service/:service_slug/user/:user_identifier/public-file', type: :request do
+  let(:service_slug) { 'my-service' }
+  let(:user_identifier) { SecureRandom::uuid }
+  let(:headers) do
+    { 'content-type' => 'application/json' }
+  end
+  let(:url) { "/service/#{service_slug}/user/#{user_identifier}/public-file" }
+  let(:body) { { url: 'http://fb-user-filestore-api-svc-test-dev.formbuilder-platform-test-dev/service/ioj/user/a239313d-4d2d-4a16-b5ef-69d6e8e53e86/28d-aaa59621acecd4b1596dd0e96968c6cec3fae7927613a12c357e7a62e1187aaa' } }
+
+  it 'responds with a 201 created' do
+    post url, params: body.to_json, headers: headers
+    expect(response.status).to eq(201)
+  end
+end

--- a/spec/requests/public_file_spec.rb
+++ b/spec/requests/public_file_spec.rb
@@ -13,4 +13,11 @@ RSpec.describe 'POST /service/:service_slug/user/:user_identifier/public-file', 
     post url, params: body.to_json, headers: headers
     expect(response.status).to eq(201)
   end
+
+  context 'without the correct payload' do
+    it 'responds with error message' do
+      post url, params: {}.to_json, headers: headers
+      expect(response.status).to eq(400)
+    end
+  end
 end


### PR DESCRIPTION
Just a simple endpoint.

To come in the next PR:
1. Make a copy of the file, encrypt it with a new key and send to a new s3 bucket
2. Return new url