### PR TITLE
Use Aws:S3:Client over Aws:S3:Object

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,12 +120,12 @@ workflows:
   test_and_build:
     jobs:
       - test
-      - build_and_deploy_to_test
-          # requires:
-          #   - test
-          # filters:
-          #   branches:
-          #     only: master
+      - build_and_deploy_to_test:
+          requires:
+            - test
+          filters:
+            branches:
+              only: master
       - confirm_integration_deploy:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,12 +120,12 @@ workflows:
   test_and_build:
     jobs:
       - test
-      - build_and_deploy_to_test:
-          requires:
-            - test
-          filters:
-            branches:
-              only: master
+      - build_and_deploy_to_test
+          # requires:
+          #   - test
+          # filters:
+          #   branches:
+          #     only: master
       - confirm_integration_deploy:
           type: approval
           requires:

--- a/app/services/storage/s3/downloader.rb
+++ b/app/services/storage/s3/downloader.rb
@@ -9,7 +9,12 @@ module Storage
       end
 
       def exists?
-        client.head_object({bucket: bucket, key: key})
+        begin
+          client.head_object(bucket: bucket, key: key)
+          true
+        rescue Aws::S3::Errors::NotFound
+          false
+        end
       end
 
       def purge_from_source!

--- a/app/services/storage/s3/downloader.rb
+++ b/app/services/storage/s3/downloader.rb
@@ -9,11 +9,11 @@ module Storage
       end
 
       def exists?
-        object.exists?
+        client.head_object({bucket: bucket, key: key})
       end
 
       def purge_from_source!
-        object.delete
+        client.delete_object(bucket: bucket, key: key)
       end
 
       def purge_from_destination!
@@ -30,7 +30,11 @@ module Storage
       attr_accessor :key
 
       def download
-        object.download_file(temp_file.path)
+        client.get_object(
+          response_target: temp_file.path,
+          bucket: bucket,
+          key: key
+        )
         decrypt(temp_file.path)
       end
 
@@ -43,15 +47,11 @@ module Storage
         file.close
       end
 
-      def object
-        @object ||= Aws::S3::Object.new(bucket_name, key, client: client)
-      end
-
       def temp_file
         @temp_file ||= Tempfile.new
       end
 
-      def bucket_name
+      def bucket
         ENV['AWS_S3_BUCKET_NAME']
       end
 

--- a/app/services/storage/s3/uploader.rb
+++ b/app/services/storage/s3/uploader.rb
@@ -32,7 +32,7 @@ module Storage
 
       def created_at
         meta_data = client.head_object({bucket: bucket, key: key})
-        meta_data[:last_modified]
+        meta_data.last_modified
       end
 
       private

--- a/app/services/storage/s3/uploader.rb
+++ b/app/services/storage/s3/uploader.rb
@@ -18,7 +18,12 @@ module Storage
       end
 
       def exists?
-        client.head_object({bucket: bucket, key: key})
+        begin
+          client.head_object(bucket: bucket, key: key)
+          true
+        rescue Aws::S3::Errors::NotFound
+          false
+        end
       end
 
       def purge_from_s3!

--- a/app/services/storage/s3/uploader.rb
+++ b/app/services/storage/s3/uploader.rb
@@ -11,20 +11,23 @@ module Storage
 
       def upload
         encrypt
-        object.upload_file(path_to_encrypted_file)
+        File.open(path_to_encrypted_file, 'rb') do |file|
+          client.put_object(bucket: bucket, key: key, body: file)
+        end
         File.delete(path_to_encrypted_file)
       end
 
       def exists?
-        object.exists?
+        client.head_object({bucket: bucket, key: key})
       end
 
       def purge_from_s3!
-        object.delete
+        client.delete_object(bucket: bucket, key: key)
       end
 
       def created_at
-        object.last_modified
+        meta_data = client.head_object({bucket: bucket, key: key})
+        meta_data[:last_modified]
       end
 
       private
@@ -58,11 +61,7 @@ module Storage
         Rails.root.join('tmp/files/encrypted_data/')
       end
 
-      def object
-        @object ||= Aws::S3::Object.new(bucket_name, key, client: client)
-      end
-
-      def bucket_name
+      def bucket
         ENV['AWS_S3_BUCKET_NAME']
       end
 

--- a/spec/services/storage/s3/uploader_spec.rb
+++ b/spec/services/storage/s3/uploader_spec.rb
@@ -1,84 +1,69 @@
 require 'rails_helper'
 
 RSpec.describe Storage::S3::Uploader do
-  let(:test_client) { Aws::S3::Client.new(stub_responses: stub_responses) }
-
-  before :each do
-    allow(Aws::S3::Client).to receive(:new).and_return(test_client)
-  end
-
+  let(:s3) { Aws::S3::Client.new(stub_responses: true) }
   let(:path) { file_fixture('lorem_ipsum.txt') }
   let(:key) { '28d/service-slug/upload-fingerprint' }
+  let(:downloader) { Storage::S3::Downloader.new(key: key) }
+  let(:subject) { described_class.new(path: path, key: key) }
 
-  subject do
-    described_class.new(path: path, key: key)
+  before :each do
+    allow(Aws::S3::Client).to receive(:new).and_return(s3)
   end
 
-  let(:downloader) { Storage::S3::Downloader.new(key: key) }
-
-  describe '#upload' do
-    describe do
-      context do
-        let(:stub_responses) do
-          {
-            head_object: [ false, { content_length: 150 } ],
-            put_object: [{}],
-          }
-        end
-
-        it 'uploads file to s3' do
-          expect(subject.exists?).to be_falsey
-          subject.upload
-          expect(subject.exists?).to be_truthy
-        end
+  describe '#exists?' do
+    context 'when a file does not exist in s3' do
+      before do
+        s3.stub_responses(:head_object, 'NotFound')
       end
 
-      context do
-        let(:stub_responses) do
-          {
-            head_object: [ { content_length: 150 } ],
-            put_object: [{}],
-            get_object: [{ body: "ce030d6aac29d4a5a8b03f7428ff4626" }]
-          }
-        end
-
-        it 'encrypts file contents' do
-          subject.upload
-
-          # prevent decryption of downloaded file
-          allow(downloader).to receive(:decrypt)
-
-          expect(downloader.contents).to eql('ce030d6aac29d4a5a8b03f7428ff4626')
-        end
-
-        it 'deletes temporary files' do
-          subject.upload
-          expect(File.exist?(subject.send(:path_to_encrypted_file))).to be_falsey
-        end
+      it 'returns false' do
+        expect(subject.exists?).to eq(false)
       end
     end
 
-    around :each do |example|
-      example.run
-      subject.purge_from_s3!
+    context 'when a file exists in s3' do
+      before do
+        s3.stub_responses(:head_object, {})
+      end
+
+      it 'returns true' do
+        expect(subject.exists?).to eq(true)
+      end
+    end
+  end
+
+
+  describe '#upload' do
+    let(:bucket) { ENV['AWS_S3_BUCKET_NAME'] }
+
+    before do
+      s3.stub_responses(:put_object, {})
+    end
+
+    it 'uploads file to s3' do
+      expect(s3).to receive(:put_object).once
+      subject.upload
+    end
+
+    it 'deletes temporary files' do
+      subject.upload
+      expect(File.exist?(subject.send(:path_to_encrypted_file))).to be_falsey
     end
   end
 
   describe '#created_at' do
     let(:now) { Time.now.utc }
 
-    let(:stub_responses) do
-      {
-        head_object: [
-          { content_length: 150, last_modified: now },
-        ],
-        put_object: [{}],
-      }
+    before do
+      s3.stub_responses(
+        :head_object,
+        Aws::S3::Types::HeadObjectOutput.new(last_modified: now)
+      )
     end
 
     it 'returns creation timestamp' do
-      subject.upload
-      expect(subject.created_at).to be_within(10.seconds).of(now)
+      expect(subject.created_at).to eq(now)
     end
   end
 end


### PR DESCRIPTION
We currently use a mix of `Aws:S3:Client` and `Aws:S3:Object` in the S3 adapters.

In order to make use of S3's stubbing features, we need to use `Aws:S3:Client` to interact with S3. This means we can do things like:
```
  client = Aws::S3::Client.new(stub_responses: true)
  client.stub_responses(:list_buckets, { buckets: [{ name: "my-bucket" }] })
  client.list_buckets.buckets.map(&:name) #=> ['my-bucket']
```

See https://aws.amazon.com/blogs/developer/advanced-client-stubbing-in-the-aws-sdk-for-ruby-version-3/