### PR TITLE
Inject bucket name into Uploader and Downloader

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -21,7 +21,11 @@ class DownloadsController < ApplicationController
   end
 
   def downloader
-    @downloader ||= Storage::S3::Downloader.new(key: key)
+    @downloader ||= Storage::S3::Downloader.new(key: key, bucket: bucket)
+  end
+
+  def bucket
+    ENV['AWS_S3_BUCKET_NAME']
   end
 
   def file_fingerprint

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -9,6 +9,7 @@ class UploadsController < ApplicationController
       user_id: params[:user_id],
       service_slug: params[:service_slug],
       encrypted_user_id_and_token: params[:encrypted_user_id_and_token],
+      bucket: bucket,
       options: {
         max_size: params[:policy][:max_size],
         allowed_types: params[:policy][:allowed_types],
@@ -116,5 +117,9 @@ class UploadsController < ApplicationController
   def error_virus_error
     render json: { code: 400,
                    name: 'invalid.virus' }, status: 400
+  end
+
+  def bucket
+    ENV['AWS_S3_BUCKET_NAME']
   end
 end

--- a/app/services/file_manager.rb
+++ b/app/services/file_manager.rb
@@ -5,11 +5,13 @@ class FileManager
   attr_reader :file
 
   def initialize(encoded_file:, user_id:, service_slug:,
-    encrypted_user_id_and_token:, options: {})
+    encrypted_user_id_and_token:, bucket:, options: {}
+  )
     @encoded_file = encoded_file
     @user_id = user_id
     @service_slug = service_slug
     @encrypted_user_id_and_token = encrypted_user_id_and_token
+    @bucket = bucket
     @max_size = options[:max_size] ? options[:max_size].to_i : nil
     @allowed_types = options.fetch(:allowed_types, [])
     @days_to_live = options.fetch(:days_to_live, 28).to_i
@@ -76,11 +78,11 @@ class FileManager
 
   private
 
-  attr_accessor :encoded_file, :user_id, :service_slug, :max_size,
+  attr_accessor :encoded_file, :user_id, :service_slug, :max_size, :bucket,
                 :allowed_types, :days_to_live, :encrypted_user_id_and_token
 
   def uploader
-    Storage::S3::Uploader.new(path: path_to_file, key: key)
+    Storage::S3::Uploader.new(path: path_to_file, key: key, bucket: bucket)
   end
 
   def key

--- a/app/services/storage/s3/downloader.rb
+++ b/app/services/storage/s3/downloader.rb
@@ -4,8 +4,9 @@ require 'tempfile'
 module Storage
   module S3
     class Downloader
-      def initialize(key:)
+      def initialize(key:, bucket:)
         @key = key
+        @bucket = bucket
       end
 
       def exists?
@@ -32,7 +33,7 @@ module Storage
 
       private
 
-      attr_accessor :key
+      attr_accessor :key, :bucket
 
       def download
         client.get_object(
@@ -54,10 +55,6 @@ module Storage
 
       def temp_file
         @temp_file ||= Tempfile.new
-      end
-
-      def bucket
-        ENV['AWS_S3_BUCKET_NAME']
       end
 
       def client

--- a/app/services/storage/s3/uploader.rb
+++ b/app/services/storage/s3/uploader.rb
@@ -4,9 +4,10 @@ require 'pathname'
 module Storage
   module S3
     class Uploader
-      def initialize(path:, key:)
+      def initialize(path:, key:, bucket:)
         @path = Pathname.new(path)
         @key = key
+        @bucket = bucket
       end
 
       def upload
@@ -37,7 +38,7 @@ module Storage
 
       private
 
-      attr_accessor :path, :key
+      attr_accessor :path, :key, :bucket
 
       def encrypt
         file = File.open(path, 'rb')
@@ -64,10 +65,6 @@ module Storage
 
       def encrypted_folder
         Rails.root.join('tmp/files/encrypted_data/')
-      end
-
-      def bucket
-        ENV['AWS_S3_BUCKET_NAME']
       end
 
       def client

--- a/spec/services/file_manager_spec.rb
+++ b/spec/services/file_manager_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe FileManager do
   let(:service_token) { SecureRandom.hex }
   let(:service_slug) { 'service-slug' }
   let(:encrypted_user_id_and_token) { SecureRandom.hex(16) }
+  let(:bucket) { ENV['AWS_S3_BUCKET_NAME'] }
   let(:s3) { Aws::S3::Client.new(stub_responses: true) }
 
   let(:subject) do
@@ -14,7 +15,8 @@ RSpec.describe FileManager do
       encoded_file: encoded_file,
       user_id: user_id,
       service_slug: service_slug,
-      encrypted_user_id_and_token: encrypted_user_id_and_token
+      encrypted_user_id_and_token: encrypted_user_id_and_token,
+      bucket: bucket
     )
   end
 
@@ -41,6 +43,7 @@ RSpec.describe FileManager do
                             user_id: user_id,
                             service_slug: service_slug,
                             encrypted_user_id_and_token: encrypted_user_id_and_token,
+                            bucket: bucket,
                             options: { max_size: '1300' })
       end
 
@@ -55,6 +58,7 @@ RSpec.describe FileManager do
                             user_id: user_id,
                             service_slug: service_slug,
                             encrypted_user_id_and_token: encrypted_user_id_and_token,
+                            bucket: bucket,
                             options: { max_size: '1400' })
       end
 
@@ -77,6 +81,7 @@ RSpec.describe FileManager do
                             user_id: user_id,
                             service_slug: service_slug,
                             encrypted_user_id_and_token: encrypted_user_id_and_token,
+                            bucket: bucket,
                             options: { allowed_types: ['image/png'] })
       end
 
@@ -91,6 +96,7 @@ RSpec.describe FileManager do
                             user_id: user_id,
                             service_slug: service_slug,
                             encrypted_user_id_and_token: encrypted_user_id_and_token,
+                            bucket: bucket,
                             options: { allowed_types: ['plain/text'] })
       end
 

--- a/spec/services/storage/s3/downloader_spec.rb
+++ b/spec/services/storage/s3/downloader_spec.rb
@@ -3,20 +3,18 @@ require 'rails_helper'
 RSpec.describe Storage::S3::Downloader do
   let(:upload_client) { Aws::S3::Client.new(stub_responses: upload_responses) }
   let(:download_client) { Aws::S3::Client.new(stub_responses: download_responses) }
-
   let(:download_responses) { {} }
   let(:upload_responses) { {} }
-
-  let(:uploader) { Storage::S3::Uploader.new(path: path, key: key) }
-  subject { described_class.new(key: key) }
+  let(:path) { file_fixture('lorem_ipsum.txt') }
+  let(:key) { '28d/service-slug/download-fingerprint' }
+  let(:bucket) { ENV['AWS_S3_BUCKET_NAME'] }
+  let(:uploader) { Storage::S3::Uploader.new(path: path, key: key, bucket: bucket) }
+  let(:subject) { described_class.new(key: key, bucket: bucket) }
 
   before :each do
     allow(uploader).to receive(:client).and_return(upload_client)
     allow(subject).to receive(:client).and_return(download_client)
   end
-
-  let(:path) { file_fixture('lorem_ipsum.txt') }
-  let(:key) { '28d/service-slug/download-fingerprint' }
 
   describe '#contents' do
     before :each do

--- a/spec/services/storage/s3/uploader_spec.rb
+++ b/spec/services/storage/s3/uploader_spec.rb
@@ -4,8 +4,9 @@ RSpec.describe Storage::S3::Uploader do
   let(:s3) { Aws::S3::Client.new(stub_responses: true) }
   let(:path) { file_fixture('lorem_ipsum.txt') }
   let(:key) { '28d/service-slug/upload-fingerprint' }
-  let(:downloader) { Storage::S3::Downloader.new(key: key) }
-  let(:subject) { described_class.new(path: path, key: key) }
+  let(:bucket) { ENV['AWS_S3_BUCKET_NAME'] }
+  let(:downloader) { Storage::S3::Downloader.new(key: key, bucket: bucket) }
+  let(:subject) { described_class.new(path: path, key: key, bucket: bucket) }
 
   before :each do
     allow(Aws::S3::Client).to receive(:new).and_return(s3)
@@ -35,8 +36,6 @@ RSpec.describe Storage::S3::Uploader do
 
 
   describe '#upload' do
-    let(:bucket) { ENV['AWS_S3_BUCKET_NAME'] }
-
     before do
       s3.stub_responses(:put_object, {})
     end


### PR DESCRIPTION
We will be saving the publicly available files in a different S3 bucket. In order to re-use the Uploader/Downloader classes, we need to be able to inject a different S3 bucket name.

This PR just implements this bucket name injection.