### PR TITLE
Allow different encryption keys to be used for Cryptography

### DIFF
--- a/app/services/cryptography.rb
+++ b/app/services/cryptography.rb
@@ -1,6 +1,7 @@
 class Cryptography
-  def initialize(encryption_key:)
+  def initialize(encryption_key:, encryption_iv:)
     @encryption_key = encryption_key
+    @encryption_iv = encryption_iv
   end
 
   def encrypt(file:)
@@ -23,11 +24,7 @@ class Cryptography
     @cipher ||= OpenSSL::Cipher.new 'AES-256-CBC'
   end
 
-  def encryption_iv
-    ENV['ENCRYPTION_IV']
-  end
-
   private
 
-  attr_accessor :encryption_key
+  attr_accessor :encryption_key, :encryption_iv
 end

--- a/app/services/cryptography.rb
+++ b/app/services/cryptography.rb
@@ -1,21 +1,21 @@
 class Cryptography
-  def initialize(file:)
-    @file = file
+  def initialize(encryption_key:)
+    @encryption_key = encryption_key
   end
 
-  def encrypt
+  def encrypt(file:)
     cipher.encrypt
     cipher.iv = encryption_iv
     cipher.key = encryption_key
-    encrypted_data = cipher.update(@file) + cipher.final
+    encrypted_data = cipher.update(file) + cipher.final
     encrypted_data.unpack1('H*')
   end
 
-  def decrypt
+  def decrypt(file:)
     cipher.decrypt
     cipher.iv = encryption_iv
     cipher.key = encryption_key
-    data = [@file].pack('H*').unpack('C*').pack('c*')
+    data = [file].pack('H*').unpack('C*').pack('c*')
     cipher.update(data) + cipher.final
   end
 
@@ -27,7 +27,7 @@ class Cryptography
     ENV['ENCRYPTION_IV']
   end
 
-  def encryption_key
-    ENV['ENCRYPTION_KEY']
-  end
+  private
+
+  attr_accessor :encryption_key
 end

--- a/app/services/storage/s3/downloader.rb
+++ b/app/services/storage/s3/downloader.rb
@@ -47,7 +47,7 @@ module Storage
       def decrypt(file)
         file = File.open(file, 'rb')
         data = file.read
-        result = Cryptography.new(file: data).decrypt
+        result = Cryptography.new(encryption_key: encryption_key).decrypt(file: data)
         file = File.open(file, 'wb')
         file.write(result)
         file.close
@@ -59,6 +59,10 @@ module Storage
 
       def client
         @client ||= Aws::S3::Client.new
+      end
+
+      def encryption_key
+        ENV['ENCRYPTION_KEY']
       end
     end
   end

--- a/app/services/storage/s3/downloader.rb
+++ b/app/services/storage/s3/downloader.rb
@@ -47,7 +47,11 @@ module Storage
       def decrypt(file)
         file = File.open(file, 'rb')
         data = file.read
-        result = Cryptography.new(encryption_key: encryption_key).decrypt(file: data)
+        result = Cryptography.new(
+          encryption_key: encryption_key,
+          encryption_iv: encryption_iv
+        ).decrypt(file: data)
+
         file = File.open(file, 'wb')
         file.write(result)
         file.close
@@ -63,6 +67,10 @@ module Storage
 
       def encryption_key
         ENV['ENCRYPTION_KEY']
+      end
+
+      def encryption_iv
+        ENV['ENCRYPTION_IV']
       end
     end
   end

--- a/app/services/storage/s3/uploader.rb
+++ b/app/services/storage/s3/uploader.rb
@@ -44,7 +44,7 @@ module Storage
         file = File.open(path, 'rb')
         data = file.read
         file.close
-        result = Cryptography.new(file: data).encrypt
+        result = Cryptography.new(encryption_key: encryption_key).encrypt(file: data)
         save_encrypted_to_disk(result)
       end
 
@@ -73,6 +73,10 @@ module Storage
 
       def random_filename
         @random_filename ||= SecureRandom.hex
+      end
+
+      def encryption_key
+        ENV['ENCRYPTION_KEY']
       end
     end
   end

--- a/app/services/storage/s3/uploader.rb
+++ b/app/services/storage/s3/uploader.rb
@@ -44,7 +44,11 @@ module Storage
         file = File.open(path, 'rb')
         data = file.read
         file.close
-        result = Cryptography.new(encryption_key: encryption_key).encrypt(file: data)
+        result = Cryptography.new(
+          encryption_key: encryption_key,
+          encryption_iv: encryption_iv
+        ).encrypt(file: data)
+
         save_encrypted_to_disk(result)
       end
 
@@ -77,6 +81,10 @@ module Storage
 
       def encryption_key
         ENV['ENCRYPTION_KEY']
+      end
+
+      def encryption_iv
+        ENV['ENCRYPTION_IV']
       end
     end
   end

--- a/spec/services/cryptography_spec.rb
+++ b/spec/services/cryptography_spec.rb
@@ -1,10 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Cryptography do
+  let(:encryption_key) { ENV['ENCRYPTION_KEY'] }
+  let(:cryptography) { Cryptography.new(encryption_key: encryption_key) }
+
   describe '#encrypt' do
     let(:file) { file_fixture('lorem_ipsum.txt').read }
-    let(:cryptography) { Cryptography.new(file: file) }
-    let(:encrypted_data) { cryptography.encrypt }
+    let(:encrypted_data) { cryptography.encrypt(file: file) }
     let(:data) { 'ce030d6aac29d4a5a8b03f7428ff4626' }
 
     it 'changes the file content using AES-256 encryption' do
@@ -17,15 +19,14 @@ RSpec.describe Cryptography do
     let(:plain_text_file) { file_fixture('lorem_ipsum.txt').read }
 
     before do
-      encrypted_file = Cryptography.new(file: plain_text_file).encrypt
+      encrypted_file = cryptography.encrypt(file: plain_text_file)
       file = File.open('spec/fixtures/files/encrypted_file', 'wb')
       file.write(encrypted_file)
       file.close
     end
 
     let(:file) { file_fixture('encrypted_file').read }
-    let(:cryptography) { Cryptography.new(file: file) }
-    let(:decrypted_data) { cryptography.decrypt }
+    let(:decrypted_data) { cryptography.decrypt(file: file) }
 
     it 'converts encrypted data back to plain text' do
       expect(decrypted_data).to eq(plain_text_file)

--- a/spec/services/cryptography_spec.rb
+++ b/spec/services/cryptography_spec.rb
@@ -2,7 +2,13 @@ require 'rails_helper'
 
 RSpec.describe Cryptography do
   let(:encryption_key) { ENV['ENCRYPTION_KEY'] }
-  let(:cryptography) { Cryptography.new(encryption_key: encryption_key) }
+  let(:encryption_iv) { ENV['ENCRYPTION_IV'] }
+  let(:cryptography) do
+    Cryptography.new(
+      encryption_key: encryption_key,
+      encryption_iv: encryption_iv
+    )
+  end
 
   describe '#encrypt' do
     let(:file) { file_fixture('lorem_ipsum.txt').read }


### PR DESCRIPTION
Encryption of files currently uses an encryption key and an encryption iv. These are set as env vars.

For the files that are going to be served to external 3rd parties, we will be re-encrypting files with a new key that is not the globally available `ENV['ENCRYPTION_KEY']`.

By injecting the encryption key and encryption iv to the `Cryptography` class we free ourselves to use different encryption keys.

The class has been changed to take the keys as constructor params and the file as an argument on encryption and decryption.