### PR TITLE
Remove encryption from uploader

### DIFF
--- a/app/services/file_manager.rb
+++ b/app/services/file_manager.rb
@@ -51,11 +51,8 @@ class FileManager
   def upload
     file_data = decode_file_data(encoded_file)
     encrypted_file_data = encrypt_file_data(file_data)
-    file_object = generate_temp_file(encrypted_file_data)
 
-    uploader.upload(file: file_object)
-
-    delete_temp_file(file_object)
+    uploader.upload(file_data: encrypted_file_data)
   end
 
   def file_fingerprint
@@ -89,17 +86,6 @@ class FileManager
 
   def uploader
     Storage::S3::Uploader.new(key: key, bucket: bucket)
-  end
-
-  def generate_temp_file(data)
-    tmp_file = Tempfile.new
-    tmp_file.write(data)
-    tmp_file.rewind
-    tmp_file
-  end
-
-  def delete_temp_file(file_object)
-    file_object.unlink
   end
 
   def decode_file_data(data)

--- a/app/services/storage/s3/uploader.rb
+++ b/app/services/storage/s3/uploader.rb
@@ -9,7 +9,7 @@ module Storage
         @bucket = bucket
       end
 
-      def upload(file: file)
+      def upload(file:)
         client.put_object(bucket: bucket, key: key, body: file.read)
       end
 

--- a/app/services/storage/s3/uploader.rb
+++ b/app/services/storage/s3/uploader.rb
@@ -9,8 +9,8 @@ module Storage
         @bucket = bucket
       end
 
-      def upload(file:)
-        client.put_object(bucket: bucket, key: key, body: file.read)
+      def upload(file_data:)
+        client.put_object(bucket: bucket, key: key, body: file_data)
       end
 
       def exists?

--- a/app/services/storage/s3/uploader.rb
+++ b/app/services/storage/s3/uploader.rb
@@ -4,18 +4,13 @@ require 'pathname'
 module Storage
   module S3
     class Uploader
-      def initialize(path:, key:, bucket:)
-        @path = Pathname.new(path)
+      def initialize(key:, bucket:)
         @key = key
         @bucket = bucket
       end
 
-      def upload
-        encrypt
-        File.open(path_to_encrypted_file, 'rb') do |file|
-          client.put_object(bucket: bucket, key: key, body: file)
-        end
-        File.delete(path_to_encrypted_file)
+      def upload(file: file)
+        client.put_object(bucket: bucket, key: key, body: file.read)
       end
 
       def exists?
@@ -32,59 +27,16 @@ module Storage
       end
 
       def created_at
-        meta_data = client.head_object({bucket: bucket, key: key})
+        meta_data = client.head_object(bucket: bucket, key: key)
         meta_data.last_modified
       end
 
       private
 
-      attr_accessor :path, :key, :bucket
-
-      def encrypt
-        file = File.open(path, 'rb')
-        data = file.read
-        file.close
-        result = Cryptography.new(
-          encryption_key: encryption_key,
-          encryption_iv: encryption_iv
-        ).encrypt(file: data)
-
-        save_encrypted_to_disk(result)
-      end
-
-      def save_encrypted_to_disk(data)
-        ensure_encrypted_folder_exists
-        encrypted_file = File.open(path_to_encrypted_file, 'wb')
-        encrypted_file.write(data)
-        encrypted_file.close
-      end
-
-      def path_to_encrypted_file
-        @path_to_encrypted_file ||= Rails.root.join('tmp/files/encrypted_data/', random_filename)
-      end
-
-      def ensure_encrypted_folder_exists
-        FileUtils.mkdir_p(encrypted_folder)
-      end
-
-      def encrypted_folder
-        Rails.root.join('tmp/files/encrypted_data/')
-      end
+      attr_accessor :key, :bucket
 
       def client
         @client ||= Aws::S3::Client.new
-      end
-
-      def random_filename
-        @random_filename ||= SecureRandom.hex
-      end
-
-      def encryption_key
-        ENV['ENCRYPTION_KEY']
-      end
-
-      def encryption_iv
-        ENV['ENCRYPTION_IV']
       end
     end
   end

--- a/spec/services/storage/s3/downloader_spec.rb
+++ b/spec/services/storage/s3/downloader_spec.rb
@@ -8,35 +8,25 @@ RSpec.describe Storage::S3::Downloader do
   let(:path) { file_fixture('lorem_ipsum.txt') }
   let(:key) { '28d/service-slug/download-fingerprint' }
   let(:bucket) { ENV['AWS_S3_BUCKET_NAME'] }
-  let(:uploader) { Storage::S3::Uploader.new(path: path, key: key, bucket: bucket) }
   let(:subject) { described_class.new(key: key, bucket: bucket) }
 
   before :each do
-    allow(uploader).to receive(:client).and_return(upload_client)
     allow(subject).to receive(:client).and_return(download_client)
   end
 
   describe '#contents' do
-    before :each do
-      uploader.upload
-    end
-
     describe do
       let(:download_responses) do
         {
           head_object: [{ content_length: 150 }],
-          get_object: [{ body: "ce030d6aac29d4a5a8b03f7428ff4626" }]
+          get_object: [{ body: "ce030d6aac29d4a5a8b03f7428ff4626" }],
+          delete_object: {}
         }
       end
 
       it 'contains correct contents' do
         expect(subject.contents).to eql("lorem ipsum\n")
       end
-    end
-
-    after :each do
-      subject.purge_from_source!
-      subject.purge_from_destination!
     end
   end
 end

--- a/spec/services/storage/s3/uploader_spec.rb
+++ b/spec/services/storage/s3/uploader_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe Storage::S3::Uploader do
 
 
   describe '#upload' do
-    let(:file) do
-      File.new(file_fixture('lorem_ipsum.txt'), 'rb')
+    let(:file_data) do
+      File.read(file_fixture('lorem_ipsum.txt'))
     end
 
     before do
@@ -44,9 +44,8 @@ RSpec.describe Storage::S3::Uploader do
     end
 
     it 'uploads file to s3' do
-      expect(s3).to receive(:put_object).with(bucket: bucket, key: key, body: file.read)
-      file.rewind
-      subject.upload(file: file)
+      expect(s3).to receive(:put_object).with(bucket: bucket, key: key, body: file_data)
+      subject.upload(file_data: file_data)
     end
   end
 

--- a/spec/services/storage/s3/uploader_spec.rb
+++ b/spec/services/storage/s3/uploader_spec.rb
@@ -2,11 +2,10 @@ require 'rails_helper'
 
 RSpec.describe Storage::S3::Uploader do
   let(:s3) { Aws::S3::Client.new(stub_responses: true) }
-  let(:path) { file_fixture('lorem_ipsum.txt') }
   let(:key) { '28d/service-slug/upload-fingerprint' }
   let(:bucket) { ENV['AWS_S3_BUCKET_NAME'] }
   let(:downloader) { Storage::S3::Downloader.new(key: key, bucket: bucket) }
-  let(:subject) { described_class.new(path: path, key: key, bucket: bucket) }
+  let(:subject) { described_class.new(key: key, bucket: bucket) }
 
   before :each do
     allow(Aws::S3::Client).to receive(:new).and_return(s3)
@@ -36,18 +35,18 @@ RSpec.describe Storage::S3::Uploader do
 
 
   describe '#upload' do
+    let(:file) do
+      File.new(file_fixture('lorem_ipsum.txt'), 'rb')
+    end
+
     before do
       s3.stub_responses(:put_object, {})
     end
 
     it 'uploads file to s3' do
-      expect(s3).to receive(:put_object).once
-      subject.upload
-    end
-
-    it 'deletes temporary files' do
-      subject.upload
-      expect(File.exist?(subject.send(:path_to_encrypted_file))).to be_falsey
+      expect(s3).to receive(:put_object).with(bucket: bucket, key: key, body: file.read)
+      file.rewind
+      subject.upload(file: file)
     end
   end
 


### PR DESCRIPTION
The `Uploader` class had a step that encrypted the file. 

With the upcoming feature of "re-encrypting files for JSON output", we need to encrypt a file with different keys and then upload it to S3. The existing implementation of `Uploader` meant we could not do a different means of encryption.

This PR pulls the encryption step out of the `Uploader` class. Instead the `Uploader` will simply upload to S3 whatever file it is given. The file needs to be encrypted before it gets to the uploader.

I've also cut out the write and subsequent read from disk that was happening in the uploader controller. We now just pass the encrypted data thats already in memory.

This gives the `Uploader` a single responsibility and makes it more general use.