### PR TITLE
New credentials and details for JSON Output S3 bucket

### DIFF
--- a/deploy/fb-user-filestore-chart/templates/deployment.yaml
+++ b/deploy/fb-user-filestore-chart/templates/deployment.yaml
@@ -84,6 +84,26 @@ spec:
               secretKeyRef:
                 name: fb-user-filestore-api-secrets-{{ .Values.environmentName }}
                 key: sentry_dsn
+          - name: AWS_S3_EXTERNAL_BUCKET_NAME
+            valueFrom:
+              secretKeyRef:
+                name: json-output-attachments-s3-bucket-{{ .Values.environmentName }}
+                key: bucket_name
+          - name: AWS_S3_EXTERNAL_BUCKET_ARN
+            valueFrom:
+              secretKeyRef:
+                name: json-output-attachments-s3-bucket-{{ .Values.environmentName }}
+                key: bucket_arn
+          - name: AWS_S3_EXTERNAL_BUCKET_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: json-output-attachments-s3-bucket-{{ .Values.environmentName }}
+                key: access_key_id
+          - name: AWS_S3_EXTERNAL_BUCKET_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: json-output-attachments-s3-bucket-{{ .Values.environmentName }}
+                key: secret_access_key
       volumes:
         - name: tmp-files
           emptyDir: {}


### PR DESCRIPTION
These are used to place newly encrypted files into the S3 bucket which we will
use to get pre-signed URLs.  These URLs will be passed to external APIs to fetch
these attachments from.