### PR TITLE
Pass client to signer

### DIFF
--- a/app/controllers/presigned_s3_urls_controller.rb
+++ b/app/controllers/presigned_s3_urls_controller.rb
@@ -11,7 +11,7 @@ class PresignedS3UrlsController < ApplicationController
     uploader.upload(file_data: reencrypted_file_data)
 
     payload = {
-      url: s3_url,
+      url: uploader.s3_url,
       encryption_key: Base64.strict_encode64(encryption_key),
       encryption_iv: Base64.strict_encode64(encryption_iv)
     }
@@ -20,11 +20,6 @@ class PresignedS3UrlsController < ApplicationController
   end
 
   private
-
-  def s3_url
-    signer = Aws::S3::Presigner.new
-    signer.presigned_url(:get_object, bucket: public_bucket, key: key)
-  end
 
   def ssl
     @ssl ||= OpenSSL::Cipher.new 'AES-256-CBC'
@@ -38,8 +33,12 @@ class PresignedS3UrlsController < ApplicationController
     @uploader ||= Storage::S3::Uploader.new(
       key: key,
       bucket: public_bucket,
-      s3_config: Rails.configuration.x.s3_external_bucket_config
+      s3_config: external_bucket_s3_config
     )
+  end
+
+  def external_bucket_s3_config
+    Rails.configuration.x.s3_external_bucket_config
   end
 
   def key

--- a/app/services/storage/s3/uploader.rb
+++ b/app/services/storage/s3/uploader.rb
@@ -31,6 +31,11 @@ module Storage
         meta_data.last_modified
       end
 
+      def s3_url
+        signer = Aws::S3::Presigner.new(client: client)
+        signer.presigned_url(:get_object, bucket: bucket, key: key)
+      end
+
       private
 
       attr_accessor :key, :bucket, :s3_config


### PR DESCRIPTION
The S3 signer was using default config. It needs to be passed an existing `Client` object in order to take on its permissions.

This PR puts the `s3_url` generation into the Uploader as a client already exists there. Not idea but works for our current mission.