### PR TITLE
Ensure S3 key is always unique

### DIFF
--- a/app/controllers/presigned_s3_urls_controller.rb
+++ b/app/controllers/presigned_s3_urls_controller.rb
@@ -31,7 +31,7 @@ class PresignedS3UrlsController < ApplicationController
 
   def uploader
     @uploader ||= Storage::S3::Uploader.new(
-      key: key,
+      key: SecureRandom.uuid,
       bucket: public_bucket,
       s3_config: external_bucket_s3_config
     )


### PR DESCRIPTION
This fixes a bug where we would get the same URL with different keys for decryption