### PR TITLE
integrate with fb-acceptance-tests

### DIFF
--- a/app/controllers/concerns/jwt_authentication.rb
+++ b/app/controllers/concerns/jwt_authentication.rb
@@ -3,7 +3,7 @@ module Concerns
     extend ActiveSupport::Concern
 
     included do
-      before_action :verify_token!
+      before_action :verify_token!, unless: :disable_jwt?
 
       if ancestors.include?(Concerns::ErrorHandling)
         rescue_from Exceptions::TokenNotPresentError do |e|
@@ -16,6 +16,10 @@ module Concerns
     end
 
     private
+
+    def disable_jwt?
+      Rails.env.development?
+    end
 
     # may raise any of:
     #   TokenInvalidError

--- a/app/services/malware_scanner.rb
+++ b/app/services/malware_scanner.rb
@@ -12,10 +12,16 @@ class MalwareScanner
   end
 
   def call
+    return false if disable_malware_scanner?
+
     virus_found?
   end
 
   private
+
+  def disable_malware_scanner?
+    Rails.env.development?
+  end
 
   def virus_found?
     @virus_found ||= !scan_result.status.success?

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,4 +51,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.hosts << "filestore-app"
 end

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,0 +1,8 @@
+if Rails.env.development?
+  Aws.config.update(
+    endpoint: 'http://localstack:4572',
+    credentials: Aws::Credentials.new('qwerty', 'qwerty'),
+    region: 'us-east-1',
+    force_path_style: true,
+  )
+end


### PR DESCRIPTION
- disable jwt in development
- disable malware scanner in development
- able to use localstack in development