### PR TITLE
Remove v1 authentication

### DIFF
--- a/app/controllers/concerns/jwt_authentication.rb
+++ b/app/controllers/concerns/jwt_authentication.rb
@@ -20,18 +20,16 @@ module Concerns
     private
 
     def verify_token!
-      if request.headers['x-access-token-v2']
-        verify_v2
-      else
-        verify_v1
+      unless request.headers['x-access-token-v2']
+        raise Exceptions::TokenNotPresentError
       end
+
+      verify
     end
 
-    def verify_v2
+    def verify
       token = request.headers['x-access-token-v2']
       leeway = ENV['MAX_IAT_SKEW_SECONDS']
-
-      raise Exceptions::TokenNotPresentError.new unless token.present?
 
       begin
         hmac_secret = public_key(params[:service_slug])
@@ -42,41 +40,6 @@ module Concerns
           {
             exp_leeway: leeway,
             algorithm: 'RS256'
-          }
-        )
-
-        Rails.logger.debug("  JWT payload: #{@jwt_payload}")
-
-        # NOTE: verify_iat used to be in the JWT gem, but was removed in v2.2
-        # so we have to do it manually
-        iat_skew = @jwt_payload['iat'].to_i - Time.current.to_i
-        if iat_skew.abs > leeway.to_i
-          Rails.logger.debug("iat skew is #{iat_skew}, max is #{leeway} - INVALID")
-          raise Exceptions::TokenNotValidError.new
-        end
-
-        Rails.logger.debug "token is valid"
-      rescue StandardError => e
-        Rails.logger.debug("Couldn't parse that token - error #{e}")
-        raise Exceptions::TokenNotValidError.new
-      end
-    end
-
-    def verify_v1
-      token = request.headers['x-access-token']
-      leeway = ENV['MAX_IAT_SKEW_SECONDS']
-
-      raise Exceptions::TokenNotPresentError.new unless token.present?
-
-      begin
-        hmac_secret = service_token(params[:service_slug])
-        @jwt_payload, _header = JWT.decode(
-          token,
-          hmac_secret,
-          true,
-          {
-            exp_leeway: leeway,
-            algorithm: 'HS256'
           }
         )
 


### PR DESCRIPTION
Now that V2 authentication is in place using JWT tokens we can remove
the old v1 code.

https://trello.com/c/DaEXYM24/109-switch-to-new-auth-method-deprecate-old-auth-method-4-4

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>