### PR TITLE
Get file content length

### DIFF
--- a/app/services/storage/s3/downloader.rb
+++ b/app/services/storage/s3/downloader.rb
@@ -31,6 +31,11 @@ module Storage
         temp_file.read
       end
 
+      def content_length
+        res = client.head_object(bucket: bucket, key: key)
+        res.content_length
+      end
+
       private
 
       attr_accessor :key, :bucket

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   get '/health', to: 'health#show'
   get '/service/:service_slug/user/:user_id/:fingerprint_with_prefix', to: 'downloads#show'
+  get '/service/:service_slug/user/:user_id/:fingerprint_with_prefix/content-length', to: 'downloads#content_length'
   post '/service/:service_slug/user/:user_id', to: 'uploads#create'
   post '/service/:service_slug/user/:user_id/:fingerprint_with_prefix/presigned-s3-url', to: 'presigned_s3_urls#create'
 end

--- a/spec/requests/file_download_spec.rb
+++ b/spec/requests/file_download_spec.rb
@@ -9,9 +9,6 @@ RSpec.describe 'GET /service/{service_slug}/user/{user_id}/{fingerprint}', type:
   end
   let(:user_id) { 'user-id' }
   let(:s3) { Aws::S3::Client.new(stub_responses: true) }
-  let(:do_get!) do
-    get "/service/service-slug/user/#{user_id}/28d-fingerprint", headers: headers
-  end
   let(:fake_service) { ServiceTokenService.new(service_slug: 'service-slug') }
   let(:jwt) { JWT.encode({sub: user_id, iat: Time.current.to_i}, private_key, 'RS256') }
   let(:encoded_private_key) { 'LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBM1NUQjJMZ2gwMllrdCtMcXo5bjY5MlNwV0xFdXNUR1hEMGlmWTBuRHpmbXF4MWVlCmx6MXh4cEpPTGV0ckxncW4zN2hNak5ZMC9uQUNjTWR1RUg5S1hycmFieFhYVGwxeVkyMStnbVd4NDlOZVlESW4KYmRtKzZzNUt2TGdVTk43WFZjZVA5UHVxWnlzeENWQTRUbm1MRURLZ2xTV2JVeWZ0QmVhVENKVkk2NFoxMmRNdApQYkFneFdBZmVTTGxiN0JQbHNIbS9IMEFBTCtuYmFPQ2t3dnJQSkRMVFZPek9XSE1vR2dzMnJ4akJIRC9OV05aCnNUVlFhbzRYd2hlYnVkaGx2TWlrRVczMldLZ0t1SEhXOHpkdlU4TWozM1RYK1picVhPaWtkRE54dHd2a1hGN0wKQTNZaDhMSTVHeWQ5cDZmMjdNZmxkZ1VJSFN4Y0pweTFKOEFQcXdJREFRQUJBb0lCQUU5ZjJTQVRmemlraWZ0aQp2RXRjZnlMN0EzbXRKd2c4dDI2cDcyT3czMUg0RWg4NHlOaWFHbE5ld2lialAvWW5wdmU2NitjRkg4SlBxK0NWCkJHRnhmdDBmampXZkRrZTNiTTVaUjdaQUVDaW8vay9pMEpveU5MK015ZkNRMWRmZ1FFUXV1L0gvdnJzSEdyT3cKRW5YQVZIUzg1enlCWWczbjM4QmxjVkw4V2s4R3FlMGxCUU5RSks5dSt5ckc5NEpoUTVoMTZubXlyQ0xpWkhSTAoyWS94MTdDL3BCN1VlUVFWeDZ4aVZSdVdmT1FoWlNmT2IzRHpsYldhc2owa2pTaHdWWDFQVG5sU0lxQXo5T3krClY5M013VFBtbVNOOGFiL0pGVlVBUzhtckM2elcxc0NjcFVUTFZHRVZBUFBJcWpjMmZFKzdLVGNjVDFzWkt0MWIKb2p1R2xSa0NnWUVBL2ZuK3VZcCtxSzdiQmxkUTZCSmNsNXpkR0xybXRrWFFZR096d2cvN21zd0NVdUM3UFpGYQpJV0xBSGM4QU85eDZvUFQ0SzFPNnQzYVBtMW8vUTR1S1N2NWNGK3EwaThMemVQM2JxdnowQXBXekdPVFdiMXg5CnNBRzNIOCtIT3JNS0NXVWl3bm5pUG1PMDNXUUY0dmFoWUd1WXYzSkNSNTYxanBJOFRkMkx6QmNDZ1lFQTN1ZkwKKzdqNGE2elVBOUNrak5wSnB2VkxyQk8ydUpiRHk5NXBpSzlCU3FIellQSEw3VVBWTExFaXRGWlNBWlRWRzFHMwpWbUNxMVoraXhCcTRST0t2VldyME1mSklsUlEvQXBQY3NwVXJjRTRPcnAxRkEyNjlLdXhhdnI5dmpLMCtIbWNRClEydWNRWWdUeWFXQlNZeW9laW04QWQ2UlpJRzVLQ25uTVlhNThZMENnWUVBNUp6VG5VLzlFdm5TVGJMck1QclcKUGVNRlllMWJIMWRZYW10VXM2cVBZSmVpdjlkcXM5RFN3SnFUTkVIUWhCSENrSC94bzQ2SzAvbjA2bkloNERzTApFTlpGTDRJbFltanBvRTlpSEZmMWpSNFRTS1UwSUttd3VXM1IyT0NGYVdFZjk3VUJ4T3pScWpjMTV0TFNPYXFuCk9KT2h1ekt1VnFtVjQrL2VPSGprRGFFQ2dZQUdMVFloeTRaV3RYdEtmOFdQZ1p6NDIyTTFhWFp1dHY3Rjcydk4KTmM0QlcydDdERGd5WXViTlRqcy85QVJodHRZUTQ3ckkwZlRwNW5xRUpKbG1qMEY4aEhJdjBCN2l3cVRjVld5UQpKa0lGNHFQVmd0WWV1anJUcmFqMkVDZnZKZjNLcWVCeGZkSGVudjZ0WDhDdFlSQnFFaTM3ZjBkWUdhQWYxTWxyClBlaDVJUUtCZ1FDbmN6YU8xcUx3VktyeUc4TzF5ZUhDSjQzT1h6SENwN3VnOE90aS9ScmhWZ08wSCtEdVpXUzUKSWhydHpUeU56MExyQTdibVFLTWZ4Y3k5Y29LOG9zZnVma1pZenJxM1ZFa0ViUCtjRWdLcGtlTDlaY2RSbXZ3WQozSTZkMUlOWVUwMldPSzhiRUJBNElJNGc0ak9ZcjJJUjFzb2lWZ0E2YnVya3E3QnMrUm41WFE9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=' }
@@ -31,50 +28,110 @@ RSpec.describe 'GET /service/{service_slug}/user/{user_id}/{fingerprint}', type:
     allow(Aws::S3::Client).to receive(:new).and_return(s3)
   end
 
-  context 'when file exists' do
-    before do
-      s3.stub_responses(:head_object, {})
-      s3.stub_responses(:get_object, { body: file_fixture('encrypted_file').read })
+  context 'downloading a file' do
+    let(:do_get!) do
+      get "/service/service-slug/user/#{user_id}/28d-fingerprint", headers: headers
     end
 
-    it 'returns status 200' do
-      do_get!
-      expect(response).to be_successful
+    context 'when file exists' do
+      before do
+        s3.stub_responses(:head_object, {})
+        s3.stub_responses(:get_object, { body: file_fixture('encrypted_file').read })
+      end
+
+      it 'returns status 200' do
+        do_get!
+        expect(response).to be_successful
+      end
+
+      it 'returns file' do
+        do_get!
+        expect(response.body).to eql("lorem ipsum\n")
+      end
     end
 
-    it 'returns file' do
-      do_get!
-      expect(response.body).to eql("lorem ipsum\n")
+    context 'when file does not exist' do
+      before do
+        s3.stub_responses(:head_object, 'NotFound')
+      end
+
+      it 'returns status 404' do
+        do_get!
+        expect(response).to be_not_found
+      end
+
+      it 'returns correct json' do
+        do_get!
+        hash = JSON.parse(response.body)
+        expect(hash['code']).to eql(404)
+        expect(hash['name']).to eql('not-found')
+      end
+    end
+
+    context 'when there is a problem' do
+      it 'returns 503' do
+        downloader = double('downloader', exists?: true)
+        allow(Storage::S3::Downloader).to receive(:new).and_return(downloader)
+        allow(downloader).to receive(:contents).and_raise(StandardError.new)
+
+        do_get!
+
+        expect(response.status).to eql(503)
+      end
     end
   end
 
-  context 'when file does not exist' do
-    before do
-      s3.stub_responses(:head_object, 'NotFound')
+  context 'retrieving content length of file' do
+    let(:do_get_content_length!) do
+      get "/service/service-slug/user/#{user_id}/28d-fingerprint/content-length", headers: headers
     end
 
-    it 'returns status 404' do
-      do_get!
-      expect(response).to be_not_found
+    context 'when file exists' do
+      before do
+        s3.stub_responses(:head_object, { content_length: 99999 })
+      end
+
+      it 'returns status 200' do
+        do_get_content_length!
+        expect(response).to be_successful
+      end
+
+      it 'returns file content length' do
+        do_get_content_length!
+        expect(response.body).to eql(
+          "{\"code\":200,\"fingerprint\":\"fingerprint\",\"content_length\":99999}"
+        )
+      end
     end
 
-    it 'returns correct json' do
-      do_get!
-      hash = JSON.parse(response.body)
-      expect(hash['code']).to eql(404)
-      expect(hash['name']).to eql('not-found')
+    context 'when file does not exist' do
+      before do
+        s3.stub_responses(:head_object, 'NotFound')
+      end
+
+      it 'returns status 404' do
+        do_get_content_length!
+        expect(response).to be_not_found
+      end
+
+      it 'returns correct json' do
+        do_get_content_length!
+        hash = JSON.parse(response.body)
+        expect(hash['code']).to eql(404)
+        expect(hash['name']).to eql('not-found')
+      end
     end
-  end
 
-  context 'when there is a problem' do
-    it 'returns 503' do
-      downloader = double('downloader', exists?: true)
-      allow(Storage::S3::Downloader).to receive(:new).and_return(downloader)
-      allow(downloader).to receive(:contents).and_raise(StandardError.new)
+    context 'when there is a problem' do
+      it 'returns 503' do
+        downloader = double('downloader')
+        allow(Storage::S3::Downloader).to receive(:new).and_return(downloader)
+        allow(downloader).to receive(:content_length).and_raise(StandardError.new)
 
-      do_get!
+        do_get_content_length!
 
-      expect(response.status).to eql(503)
+        expect(response.status).to eql(503)
+      end
     end
   end
 end

--- a/spec/services/storage/s3/downloader_spec.rb
+++ b/spec/services/storage/s3/downloader_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe Storage::S3::Downloader do
       it 'contains correct contents' do
         expect(subject.contents).to eql("lorem ipsum\n")
       end
+
+      it 'has the correct content length' do
+        expect(subject.content_length).to eql(150)
+      end
     end
   end
 end


### PR DESCRIPTION
We need to allow the submitter to know the size of attachments before downloading them.

This stems from previous work which grouped attachments by file size into the lowest number of emails as possible.

We now need the submitter to be able to know how to group the attachments before downloading them so we can prevent any failed delayed jobs from resending any emails that have been successfully sent to a recipient.

https://trello.com/c/248f4veP/476-stop-looping-submission-emails-that-have-been-successfully-sent