### PR TITLE
Accept JWT skew override header 

### DIFF
--- a/app/controllers/concerns/jwt_authentication.rb
+++ b/app/controllers/concerns/jwt_authentication.rb
@@ -29,7 +29,6 @@ module Concerns
 
     def verify
       token = request.headers['x-access-token-v2']
-      leeway = ENV['MAX_IAT_SKEW_SECONDS']
 
       begin
         hmac_secret = public_key(params[:service_slug])
@@ -68,6 +67,16 @@ module Concerns
     def public_key(service_slug)
       service = ServiceTokenService.new(service_slug: service_slug)
       service.public_key
+    end
+
+    def leeway
+      @leeway ||= begin
+        if request.headers['x-jwt-skew-override'].blank?
+          ENV['MAX_IAT_SKEW_SECONDS']
+        else
+          request.headers['x-jwt-skew-override']
+        end
+      end
     end
   end
 end

--- a/spec/controllers/concerns/jwt_authentication_spec.rb
+++ b/spec/controllers/concerns/jwt_authentication_spec.rb
@@ -134,5 +134,25 @@ RSpec.describe 'Concerns::JWTAuthentication' do
         end
       end
     end
+
+    context 'when a JWT skew override header with enough extra time is supplied' do
+      let(:headers) do
+        {
+          'content-type' => 'image/jpeg',
+          'x-access-token-v2' => token,
+          'x-jwt-skew-override' => '600'
+        }
+      end
+      let(:iat) { Time.current.to_i - 300.seconds }
+      let(:algorithm) { 'RS256' }
+      let(:private_key) { OpenSSL::PKey::RSA.new(Base64.strict_decode64(encoded_private_key)) }
+      let(:token) do
+        JWT.encode payload.merge(iat: iat), private_key, algorithm
+      end
+
+      it 'successfully validates the JWT' do
+        expect(response.status).to eq(200)
+      end
+    end
   end
 end


### PR DESCRIPTION
In the event of replaying failed submissions with attachments from the Submitter we need to be able to override the lifetime of the JWT. This enables the Submitter to re-queue a previously failed delayed job that may be run after the default 60 seconds has elapsed.

[Related Submitter PR](https://github.com/ministryofjustice/fb-submitter/pull/337)

https://trello.com/c/O95ENrYl/574-replay-failed-submissions-that-have-attachments