### PR TITLE
Return unsupported file type error message

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -109,7 +109,7 @@ class UploadsController < ApplicationController
 
   def error_unsupported_file_type(type)
     render json: { code: 400,
-                   name: 'accept',
+                   name: 'invalid.unsupported-file-type',
                    type: type }, status: 400
   end
 

--- a/spec/requests/file_upload_spec.rb
+++ b/spec/requests/file_upload_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe 'FileUpload API', type: :request do
 
         it 'returns JSON with invalid type content' do
           result = JSON.parse(response.body)
-          expect(result['name']).to eq('accept')
+          expect(result['name']).to eq('invalid.unsupported-file-type')
         end
       end
 
@@ -157,7 +157,7 @@ RSpec.describe 'FileUpload API', type: :request do
 
         it 'returns JSON with invalid type content' do
           result = JSON.parse(response.body)
-          expect(result['name']).to eq('accept')
+          expect(result['name']).to eq('invalid.unsupported-file-type')
         end
       end
     end


### PR DESCRIPTION
In the instance of an unsupported file type validation failure return a more descriptive message of 'unavailable.file-store-failed' instead of 'accept'.