### PR TITLE
Update kubernetes resources

### DIFF
--- a/deploy/fb-user-filestore-chart/templates/deployment.yaml
+++ b/deploy/fb-user-filestore-chart/templates/deployment.yaml
@@ -1,11 +1,14 @@
 ---
 # web front-end
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "fb-user-filestore-api-{{ .Values.environmentName }}"
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: "fb-user-filestore-api-{{ .Values.environmentName }}"
   template:
     metadata:
       labels:


### PR DESCRIPTION
Kubernetes has been upgraded to 1.16. These changes are required for the resources to continue working.

Followed the guide here:

https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/apiversion-changes-k8s-1-16.html#resources-deployed-using-helm-charts

https://trello.com/c/w8d8G6RM/696-cloud-platform-kubernetes-update