### PR TITLE
Fix open3 constant not found when update aws sdk gem

### DIFF
--- a/app/services/malware_scanner.rb
+++ b/app/services/malware_scanner.rb
@@ -1,3 +1,5 @@
+require 'open3'
+
 class MalwareScanner
   ClamdscanError = Class.new(StandardError)
 

--- a/spec/services/malware_scanner_spec.rb
+++ b/spec/services/malware_scanner_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe MalwareScanner do
+  subject(:malware_scanner) { described_class.new(file_path: file_path) }
+
+  describe '#call' do
+    let(:file_path) { Rails.root }
+
+    context 'when development mode' do
+      it 'returns false' do
+        allow(Rails.env).to receive(:development?).and_return(true)
+        expect(malware_scanner.call).to be_falsey
+      end
+    end
+
+    context 'when virus is found' do
+      let(:pid_status) do
+        double(exitstatus: 1, success?: false)
+      end
+
+      it 'returns true' do
+        allow(Open3).to receive(:capture3).and_return(['', '', pid_status])
+        expect(malware_scanner.call).to be_truthy
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/JcNPd2Wd/770-filestore-was-unavailable)

## Context

A recent update to the aws-sdk-s3 gem removed an "Open3" require.
This causes the malware scanning to fail with the exception:

NameError
uninitialized constant MalwareScanner::Open3
The require was removed here:

[aws/aws-sdk-ruby: 45415b7](https://github.com/aws/aws-sdk-ruby/commit/45415b70caa6abb750dfdce87548734723423477#diff-3568a2917e2622663edb14d5bee2568dL3)

This commit addresses the issue and adds unit test for the malware
scanner