### PR TITLE
Trigger acceptance tests after build and deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,34 +93,40 @@ jobs:
             K8S_NAMESPACE: formbuilder-platform-live-production
           command: './deploy-scripts/bin/deploy'
   trigger_acceptance_tests:
-    docker:
-      - image: circleci/ruby:latest
+    working_directory: ~/circle/git/fb-user-filestore
+    docker: *ecr_base_image
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "71:2d:7e:c6:9c:9f:62:4e:0b:e3:d8:8d:5e:ee:ae:c2"
+      - run:
+          name: cloning deploy scripts
+          command: 'git clone git@github.com:ministryofjustice/fb-deploy.git deploy-scripts'
       - run:
           name: "Trigger Acceptance Tests"
-          command: "curl -u ${CIRCLE_TOKEN}: -X POST https://circleci.com/api/v2/project/github/ministryofjustice/fb-acceptance-tests/pipeline -H 'Content-Type: application/json' -H 'Accept: application/json'"
+          command: './deploy-scripts/bin/acceptance_tests'
 
 workflows:
   version: 2
   test_and_build:
     jobs:
       - test
-      - trigger_acceptance_tests:
-          requires:
-            - test
-          filters:
-            branches:
-              only: master
       - build_and_deploy_to_test:
           requires:
             - test
           filters:
             branches:
               only: master
+      - trigger_acceptance_tests:
+          requires:
+            - build_and_deploy_to_test
+          filters:
+            branches:
+              only: master
       - confirm_production_deploy:
           type: approval
           requires:
-            - build_and_deploy_to_test
+            - trigger_acceptance_tests
       - build_and_deploy_to_live:
           requires:
             - confirm_production_deploy


### PR DESCRIPTION
We now want the acceptance tests to run only after the build and deploy has finished.