### PR TITLE
Use build image ECR environment variable names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,10 +15,10 @@ jobs:
   build_and_deploy_to_test:
     working_directory: ~/circle/git/fb-user-filestore
     docker: &ecr_base_image
-      - image: $AWS_ECR_ACCOUNT_URL
+      - image: $AWS_BUILD_IMAGE_ECR_ACCOUNT_URL
         aws_auth:
-          aws_access_key_id: $AWS_ACCESS_KEY_ID
-          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
+          aws_access_key_id: $AWS_BUILD_IMAGE_ACCESS_KEY_ID
+          aws_secret_access_key: $AWS_BUILD_IMAGE_SECRET_ACCESS_KEY
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
This is to identify the fact that the credentials used here are related to the build image that all form builder applications use, not the credentials that the deploy script uses to interact with the app specific ECR repo.