### PR TITLE
Use CircleCI prebuilt image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     working_directory: ~/circle
     docker:
-      - image: circleci/ruby:2.6.4
+      - image: cimg/ruby:2.7.1
         environment:
           RAILS_ENV: test
     steps:


### PR DESCRIPTION
Circle have newer prebuilt images which apparently spin up faster and are more stable.

https://circleci.com/docs/2.0/circleci-images/