### PR TITLE
Migrate to use new Sentry gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,8 @@ gem 'jwt'
 gem 'metrics_adapter', '0.2.0'
 gem 'puma', '~> 5.3'
 gem 'rails', '~> 6.1.3'
-gem 'sentry-raven'
+gem 'sentry-rails', '~> 4.4.0'
+gem 'sentry-ruby', '~> 4.4.2'
 gem 'tzinfo-data'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,11 +91,15 @@ GEM
       dotenv (= 2.7.6)
       railties (>= 3.2)
     erubi (1.10.0)
-    faraday (1.3.0)
+    faraday (1.4.1)
+      faraday-excon (~> 1.1)
       faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
       multipart-post (>= 1.2, < 3)
-      ruby2_keywords
+      ruby2_keywords (>= 0.0.4)
+    faraday-excon (1.1.0)
     faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.1.0)
     ffi (1.13.1)
     formatador (0.2.5)
     globalid (0.4.2)
@@ -213,8 +217,16 @@ GEM
       rspec-support (~> 3.10)
     rspec-support (3.10.2)
     ruby2_keywords (0.0.4)
-    sentry-raven (3.1.2)
+    sentry-rails (4.4.0)
+      railties (>= 5.0)
+      sentry-ruby-core (~> 4.4.0.pre.beta)
+    sentry-ruby (4.4.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       faraday (>= 1.0)
+      sentry-ruby-core (= 4.4.2)
+    sentry-ruby-core (4.4.2)
+      concurrent-ruby
+      faraday
     shellany (0.0.1)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
@@ -248,7 +260,8 @@ DEPENDENCIES
   puma (~> 5.3)
   rails (~> 6.1.3)
   rspec-rails (~> 5.0)
-  sentry-raven
+  sentry-rails (~> 4.4.0)
+  sentry-ruby (~> 4.4.2)
   timecop
   tzinfo-data
 

--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -4,7 +4,7 @@ module Concerns
 
     included do
       rescue_from StandardError do |e|
-        Raven.capture_exception(e)
+        Sentry.capture_exception(e)
 
         args = { message: e.message }
         unless Rails.env.production?

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -54,7 +54,7 @@ class UploadsController < ApplicationController
       render json: hash, status: 201
     end
   rescue StandardError => e
-    Raven.capture_exception(e)
+    Sentry.capture_exception(e)
     return error_upload_server_error
   ensure
     @file_manager.delete_file if @file_manager

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,9 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password, :encrypted_user_id_and_token, :file]
+Rails.application.config.filter_parameters += [
+  :password,
+  :encrypted_user_id_and_token,
+  :file,
+  'X-Access-Token'
+]

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,6 +1,13 @@
-Raven.configure do |config|
-  config.dsn = ENV['SENTRY_DSN']
+Sentry.init do |config|
+  config.breadcrumbs_logger = [:active_support_logger, :http_logger]
+  config.logger =  Logger.new(STDOUT)
 
-  config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
-  config.sanitize_fields += ['X-Access-Token']
+  config.traces_sample_rate = 1
+  config.before_send = lambda do |event, _hint|
+    if event.request && event.request.data
+      filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+      event.request.data = filter.filter(event.request.data)
+    end
+    event
+  end
 end

--- a/spec/controllers/concerns/error_handling_spec.rb
+++ b/spec/controllers/concerns/error_handling_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe ApplicationController do
       end
     end
 
-    it 'calls raven (sentry) with exception' do
-      expect(Raven).to receive(:capture_exception)
+    it 'calls sentry with exception' do
+      expect(Sentry).to receive(:capture_exception)
       get :index
     end
   end
@@ -24,8 +24,8 @@ RSpec.describe ApplicationController do
       end
     end
 
-    it 'does not call raven (sentry)' do
-      expect(Raven).to_not receive(:capture_exception)
+    it 'does not call sentry' do
+      expect(Sentry).to_not receive(:capture_exception)
       get :index
     end
   end


### PR DESCRIPTION
This adds the new sentry rails and ruby gems.

Configure the cleaning of the sensitive parameters.

Also enable performance monitoring for the upcoming trial.