### PR TITLE
Check mime type does exist before uploading the file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby File.read('.ruby-version').chomp
 gem 'aws-sdk-s3', '~> 1'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'jwt'
+gem 'mime-types'
 gem 'metrics_adapter', '0.2.0'
 gem 'puma', '~> 5.4'
 gem 'rails', '~> 6.1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,9 @@ GEM
       activesupport
       keen
       mixpanel-ruby
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2021.0704)
     mini_mime (1.1.0)
     mini_portile2 (2.6.1)
     minitest (5.14.4)
@@ -267,6 +270,7 @@ DEPENDENCIES
   guard-rspec
   jwt
   metrics_adapter (= 0.2.0)
+  mime-types
   puma (~> 5.4)
   rails (~> 6.1.4)
   rspec-rails (~> 5.0)

--- a/app/services/mime_checker.rb
+++ b/app/services/mime_checker.rb
@@ -5,7 +5,7 @@ class MimeChecker
   end
 
   def call
-    return false if type.blank? || subtype.blank?
+    return false if mime_type_invalid? || type.blank? || subtype.blank?
 
     whitelist.detect do |whitelisted|
       whitelisted_type, whitelisted_subtype = whitelisted.split('/')
@@ -14,6 +14,10 @@ class MimeChecker
       (type == whitelisted_type && whitelisted_subtype == "*") ||
       (type == whitelisted_type && subtype == whitelisted_subtype)
     end
+  end
+
+  def mime_type_invalid?
+    MIME::Types[value][0].blank?
   end
 
   private

--- a/spec/services/file_manager_spec.rb
+++ b/spec/services/file_manager_spec.rb
@@ -91,17 +91,35 @@ RSpec.describe FileManager do
     end
 
     context 'when file is not permitted' do
-      subject do
-        described_class.new(encoded_file: encoded_file,
-                            user_id: user_id,
-                            service_slug: service_slug,
-                            encrypted_user_id_and_token: encrypted_user_id_and_token,
-                            bucket: bucket,
-                            options: { allowed_types: ['plain/text'] })
+      context 'when allowed types are present' do
+        subject do
+          described_class.new(encoded_file: encoded_file,
+                              user_id: user_id,
+                              service_slug: service_slug,
+                              encrypted_user_id_and_token: encrypted_user_id_and_token,
+                              bucket: bucket,
+                              options: { allowed_types: ['plain/text'] })
+        end
+
+        it 'returns false' do
+          expect(subject.type_permitted?).to be_falsey
+        end
       end
 
-      it 'returns false' do
-        expect(subject.type_permitted?).to be_falsey
+      context 'when mime type is invalid' do
+        subject do
+          described_class.new(encoded_file: encoded_file,
+                              user_id: user_id,
+                              service_slug: service_slug,
+                              encrypted_user_id_and_token: encrypted_user_id_and_token,
+                              bucket: bucket,
+                              options: { allowed_types: ['*/*'] })
+        end
+
+        it 'returns false' do
+          allow(subject).to receive(:mime_type).and_return('application/wps-writer')
+          expect(subject.type_permitted?).to be_falsey
+        end
       end
     end
   end


### PR DESCRIPTION
[Trello card](https://trello.com/c/ewXjnaAG/1795-bug-user-filestore-does-not-throw-an-error-when-mimetype-is-not-supported)

## Context

The submitter uses the mimetype when processing the submission and both filestore and submitter should be in sync

Adding this check avoid the issue of the user uploading a non supported mime type