### PR TITLE
Unpin Docker version in CircleCi config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker: &remote_docker
-          version: 20.10.11
           docker_layer_caching: true
       - run:
           name: test


### PR DESCRIPTION
CircleCI will be keeping the Docker executor up to date on a rolling basis.

Checklist
- [x] [CircleCI run](https://app.circleci.com/pipelines/github/ministryofjustice/fb-user-filestore/1251/workflows/3701df0e-a26a-4e8d-b13d-995c4c50c81b)
- [x] Upload a file to a form in Test environment
- [x] Antivirus check in Test