### PR TITLE
Add some log output to file uploads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,9 +159,7 @@ workflows:
             - test
           filters:
             branches:
-              only: 
-                - master
-                - test-upload-logs
+              only: master
       - deploy_to_test_dev:
           context: *moj-forms-context
           requires:
@@ -178,16 +176,16 @@ workflows:
           filters:
             branches:
               only: master
-      # - deploy_to_live_dev:
-      #     context: *moj-forms-context
-      #     requires:
-      #       - acceptance_tests
-      # - deploy_to_live_production:
-      #     context: *moj-forms-context
-      #     requires:
-      #       - acceptance_tests
-      # - smoke_tests:
-      #     context: *moj-forms-context
-      #     requires:
-      #       - deploy_to_live_dev
-      #       - deploy_to_live_production
+      - deploy_to_live_dev:
+          context: *moj-forms-context
+          requires:
+            - acceptance_tests
+      - deploy_to_live_production:
+          context: *moj-forms-context
+          requires:
+            - acceptance_tests
+      - smoke_tests:
+          context: *moj-forms-context
+          requires:
+            - deploy_to_live_dev
+            - deploy_to_live_production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,9 @@ workflows:
             - test
           filters:
             branches:
-              only: master
+              only: 
+                - master
+                - test-upload-logs
       - deploy_to_test_dev:
           context: *moj-forms-context
           requires:
@@ -176,16 +178,16 @@ workflows:
           filters:
             branches:
               only: master
-      - deploy_to_live_dev:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-      - deploy_to_live_production:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-      - smoke_tests:
-          context: *moj-forms-context
-          requires:
-            - deploy_to_live_dev
-            - deploy_to_live_production
+      # - deploy_to_live_dev:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - acceptance_tests
+      # - deploy_to_live_production:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - acceptance_tests
+      # - smoke_tests:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - deploy_to_live_dev
+      #       - deploy_to_live_production

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -16,9 +16,9 @@ class UploadsController < ApplicationController
         days_to_live: params[:policy][:expires]
       }
     )
-
+    Rails.logger.info('Created file manager, saving to disk...')
     @file_manager.save_to_disk
-
+    Rails.logger.info('Saved file to disk')
     if @file_manager.file_too_large?
       return error_large_file(@file_manager.file_size)
     end
@@ -26,11 +26,11 @@ class UploadsController < ApplicationController
     unless @file_manager.type_permitted?
       return error_unsupported_file_type(@file_manager.mime_type)
     end
-
+    Rails.logger.info('Virus check starting....')
     if @file_manager.has_virus?
       return error_virus_error
     end
-
+    Rails.logger.info('Virus check finished. Checking if file already exists')
     if @file_manager.file_already_exists?
       hash = {
         fingerprint: "#{@file_manager.fingerprint_with_prefix}",
@@ -42,8 +42,9 @@ class UploadsController < ApplicationController
       render json: hash, status: :ok
     else
       # async?
+      Rails.logger.info('Uploading file....')
       @file_manager.upload
-
+      Rails.logger.info('Upload to remote storage complete')
       hash = {
         fingerprint: "#{@file_manager.fingerprint_with_prefix}",
         size: @file_manager.file_size,

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -32,6 +32,7 @@ class UploadsController < ApplicationController
     end
     Rails.logger.info('Virus check finished. Checking if file already exists')
     if @file_manager.file_already_exists?
+      Rails.logger.info('File exists, returning')
       hash = {
         fingerprint: "#{@file_manager.fingerprint_with_prefix}",
         size: @file_manager.file_size,


### PR DESCRIPTION
These logs will help us pinpoint the different timings each step of uploading a file takes, and as now in dev file uploads are working smoothly and quickly we'd like to push this to live to help pinpoint what could be causing issues.