### PR TITLE
Use updated Github RSA SSH key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,7 @@ jobs:
     docker: *ecr_base_image
     resource_class: large
     steps:
+      - checkout
       - setup_remote_docker: *remote_docker
       - run: *deploy_scripts
       - run:
@@ -139,6 +140,7 @@ jobs:
   smoke_tests:
     docker: *ecr_base_image
     steps:
+      - checkout
       - setup_remote_docker: *remote_docker
       - run: *deploy_scripts
       - run:


### PR DESCRIPTION
### Add 'checkout' step to CircleCI config
Github have recently rotated their RSA SSH host key. As a result, the public key is no longer up to date in the known_host file.

The 'checkout' step automatically adds the required authenticity keys for interacting with Github. Adding this job allows the acceptance test and smoke tests steps to interact with Github.

CircleCI run:
https://app.circleci.com/pipelines/github/ministryofjustice/fb-user-filestore/1441/workflows/f8bac9fe-f9dc-4768-98e0-444009c2c197