### PR TITLE
Propagate request_id to token service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ config/clamd/*.conf
 # Ignore node_modules and package-lock.json
 node_modules
 package-lock.json
+.env.local

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
       tzinfo (~> 2.0)
     ansi (1.5.0)
     aws-eventstream (1.2.0)
-    aws-partitions (1.848.0)
+    aws-partitions (1.852.0)
     aws-sdk-core (3.186.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
@@ -123,10 +123,10 @@ GEM
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    loofah (2.21.4)
+    loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    lumberjack (1.2.9)
+    lumberjack (1.2.10)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
@@ -142,7 +142,7 @@ GEM
     minitest (5.20.0)
     msgpack (1.7.2)
     nenv (0.3.0)
-    net-imap (0.4.4)
+    net-imap (0.4.5)
       date
       net-protocol
     net-pop (0.1.2)
@@ -151,7 +151,7 @@ GEM
       timeout
     net-smtp (0.4.0)
       net-protocol
-    nio4r (2.5.9)
+    nio4r (2.6.0)
     nokogiri (1.15.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::API
+  include Concerns::SetCurrentRequestDetails
   include Concerns::ErrorHandling
 
   before_action :enforce_json_only

--- a/app/controllers/concerns/jwt_authentication.rb
+++ b/app/controllers/concerns/jwt_authentication.rb
@@ -62,10 +62,12 @@ module Concerns
     # TODO: this method seems to not be in use anymore
     # Legacy FB forms are using v2 token cache too
     # Confirm to be sure and cleanup code/tests
+    # :nocov:
     def service_token(service_slug)
       service = ServiceTokenService.new(service_slug: service_slug)
       service.get
     end
+    # :nocov:
 
     def public_key(service_slug)
       service = ServiceTokenService.new(service_slug: service_slug)

--- a/app/controllers/concerns/jwt_authentication.rb
+++ b/app/controllers/concerns/jwt_authentication.rb
@@ -47,7 +47,7 @@ module Concerns
         # NOTE: verify_iat used to be in the JWT gem, but was removed in v2.2
         # so we have to do it manually
         iat_skew = @jwt_payload['iat'].to_i - Time.current.to_i
-        if iat_skew.abs > leeway.to_i
+        if iat_skew.abs > leeway
           Rails.logger.debug("iat skew is #{iat_skew}, max is #{leeway} - INVALID")
           raise Exceptions::TokenNotValidError.new
         end
@@ -59,6 +59,9 @@ module Concerns
       end
     end
 
+    # TODO: this method seems to not be in use anymore
+    # Legacy FB forms are using v2 token cache too
+    # Confirm to be sure and cleanup code/tests
     def service_token(service_slug)
       service = ServiceTokenService.new(service_slug: service_slug)
       service.get
@@ -76,7 +79,7 @@ module Concerns
         else
           request.headers['x-jwt-skew-override']
         end
-      end
+      end.to_i
     end
   end
 end

--- a/app/controllers/concerns/set_current_request_details.rb
+++ b/app/controllers/concerns/set_current_request_details.rb
@@ -1,0 +1,11 @@
+module Concerns
+  module SetCurrentRequestDetails
+    extend ActiveSupport::Concern
+
+    included do
+      before_action do
+        Current.request_id = request.uuid
+      end
+    end
+  end
+end

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -50,19 +50,6 @@ class DownloadsController < ApplicationController
                             cipher_key: Digest::MD5.hexdigest(request.headers['x-encrypted-user-id-and-token'])).call
   end
 
-  def error_large_file(size)
-    render json: { code: 400,
-                   name: 'invalid.too-large',
-                   max_size: params[:policy][:max_size],
-                   size: size }, status: 400
-  end
-
-  def error_unsupported_file_type(type)
-    render json: { code: 400,
-                   name: 'invalid type',
-                   type: type }, status: 400
-  end
-
   def error_download_server_error
     render json: { code: 503,
                    name: 'unavailable.file-retrieval-failed' }, status: 503

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -63,6 +63,7 @@ class UploadsController < ApplicationController
     end
   rescue StandardError => e
     Sentry.capture_exception(e)
+    log("Unexpected error: #{e}")
     return error_upload_server_error
   ensure
     @file_manager.delete_file if @file_manager

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,9 @@
+# `Current` class facilitates easy access to global, per-request attributes
+# without passing them deeply around everywhere.
+# `Current` should only be used for a few, top-level globals.
+#
+# https://edgeapi.rubyonrails.org/classes/ActiveSupport/CurrentAttributes.html
+#
+class Current < ActiveSupport::CurrentAttributes
+  attribute :request_id
+end

--- a/app/services/adapters/service_token_cache_client.rb
+++ b/app/services/adapters/service_token_cache_client.rb
@@ -33,9 +33,12 @@ module Adapters
       }.freeze
     end
 
+    # TODO: this method seems to not be in use anymore
+    # :nocov:
     def service_token_uri(service_slug)
       URI.join(@root_url, '/service/', service_slug)
     end
+    # :nocov:
 
     def public_key_uri(service_slug)
       URI.join(root_url, '/service/v2/', service_slug)

--- a/app/services/adapters/service_token_cache_client.rb
+++ b/app/services/adapters/service_token_cache_client.rb
@@ -16,7 +16,7 @@ module Adapters
 
     def public_key_for(service_slug)
       url = public_key_uri(service_slug)
-      response = Net::HTTP.get_response(url)
+      response = Net::HTTP.get_response(url, headers)
 
       return unless response.code.to_i == 200
 
@@ -25,6 +25,13 @@ module Adapters
     end
 
     private
+
+    def headers
+      {
+        'User-Agent' => 'UserFilestore',
+        'X-Request-Id' => Current.request_id
+      }.freeze
+    end
 
     def service_token_uri(service_slug)
       URI.join(@root_url, '/service/', service_slug)

--- a/deploy-eks/fb-user-filestore-chart/templates/config_map.yaml
+++ b/deploy-eks/fb-user-filestore-chart/templates/config_map.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   RAILS_ENV: "production"
   RAILS_SERVE_STATIC_FILES: "false"
-  MAX_IAT_SKEW_SECONDS: "60"
+  MAX_IAT_SKEW_SECONDS: "90"
   SERVICE_TOKEN_CACHE_ROOT_URL: "http://fb-service-token-cache-svc-{{ .Values.environmentName }}/"
   AWS_REGION: "eu-west-2"
   AV_HOST: "fb-av-svc-{{ .Values.environmentName }}"

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe DownloadsController, type: :controller do
       request.headers.merge!(headers)
     end
 
+    context 'stores the current request details' do
+      it 'stores the request_id' do
+        expect(Current).to receive(:request_id=)
+        get :show, params: { service_slug:, user_id:, fingerprint_with_prefix: '28d-fingerprint' }
+      end
+    end
+
     context 'sad paths' do
       context 'missing payload' do
         it 'returns error' do

--- a/spec/controllers/uploads_controller_spec.rb
+++ b/spec/controllers/uploads_controller_spec.rb
@@ -31,6 +31,13 @@ RSpec.describe UploadsController, type: :controller do
   end
 
   describe 'POST #create' do
+    context 'stores the current request details' do
+      it 'stores the request_id' do
+        expect(Current).to receive(:request_id=)
+        post :create, params: { service_slug:, user_id: }
+      end
+    end
+
     context 'when there are missing or invalid parameters' do
       before :each do
         disable_malware_scanner!

--- a/spec/services/adapters/service_token_cache_client_spec.rb
+++ b/spec/services/adapters/service_token_cache_client_spec.rb
@@ -79,8 +79,23 @@ RSpec.describe Adapters::ServiceTokenCacheClient do
       double('response', body: {token: encoded_public_key}.to_json, code: 200)
     end
 
+    let(:expected_headers) do
+      {
+        'User-Agent' => 'UserFilestore',
+        'X-Request-Id' => '12345',
+      }
+    end
+
+    before do
+      allow(Current).to receive(:request_id).and_return('12345')
+    end
+
     it 'returns public key' do
-      expect(Net::HTTP).to receive(:get_response).with(URI('http://www.example.com/service/v2/my-service')).and_return(mock_response)
+      expect(
+        Net::HTTP
+      ).to receive(:get_response).with(
+        URI('http://www.example.com/service/v2/my-service'), expected_headers
+      ).and_return(mock_response)
 
       subject.public_key_for(service_slug)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 require 'simplecov'
 require 'simplecov-console'
 
-SimpleCov.minimum_coverage 98
+SimpleCov.minimum_coverage 100
 SimpleCov.start do
   add_filter 'config/'
   add_filter 'spec/'


### PR DESCRIPTION
Same work we've been doing in the rest of services. For some reason I overlooked this one but it calls the token service so should propagate the request_id too.

Note however because the way this http client is setup, and to limit the scope of changes, instead of passing around a `request_id` argument to many methods and classes, I'm using `ActiveSupport::CurrentAttributes` as a global object. I think in this case the pros outweighs the cons.

I've also taken the spec coverage up to 100 by way of deleting some unused methods, or annotating others as `nocov`. These unused methods seems to be for legacy/v1 and no longer in use, we should delete them once we are certain that's the case.