### PR TITLE
Rename errors without a concrete validator

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -75,31 +75,32 @@ class UploadsController < ApplicationController
     log('Checking upload params...')
 
     if params[:file].blank?
-      return render json: { code: 400, name: 'invalid.file-missing' }, status: 400
+      return render json: { code: 400, name: 'error.file-missing' }, status: 400
     end
 
     if params[:user_id].blank?
-      return render json: { code: 400, name: 'invalid.user-id-missing' }, status: 400
+      return render json: { code: 400, name: 'error.user-id-missing' }, status: 400
     end
 
     unless @jwt_payload['sub'] == params[:user_id]
-      raise Concerns::JWTAuthentication::SubjectMismatchError
+      log('There is a mismatch between the user_id and the jwt sub')
+      return render json: { code: 403, name: 'error.user-id-sub-mismatch' }, status: 403
     end
 
     if params[:encrypted_user_id_and_token].blank?
-      return render json: { code: 403, name: 'forbidden.user-id-token-missing' }, status: 403
+      return render json: { code: 403, name: 'error.user-id-token-missing' }, status: 403
     end
 
     if params[:service_slug].blank?
-      return render json: { code: 400, name: 'invalid.service-slug-missing' }, status: 400
+      return render json: { code: 400, name: 'error.service-slug-missing' }, status: 400
     end
 
     if params[:policy].blank?
-      return render json: { code: 400, name: 'invalid.policy-missing' }, status: 400
+      return render json: { code: 400, name: 'error.policy-missing' }, status: 400
     end
 
     if params[:policy][:max_size].blank?
-      return render json: { code: 400, name: 'invalid.policy-max-size-missing' }, status: 400
+      return render json: { code: 400, name: 'error.policy-max-size-missing' }, status: 400
     end
 
     if params[:policy][:allowed_types].blank?
@@ -126,7 +127,7 @@ class UploadsController < ApplicationController
 
   def error_upload_server_error
     render json: { code: 503,
-                   name: 'unavailable.file-store-failed' }, status: 503
+                   name: 'error.file-store-failed' }, status: 503
   end
 
   def error_virus_error

--- a/spec/controllers/uploads_controller_spec.rb
+++ b/spec/controllers/uploads_controller_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe UploadsController, type: :controller do
           url_params = { service_slug: 'service-slug', user_id: '12345' }
           json_params = json
           post :create, params: url_params.merge(json_params)
-          expect(response).to be_server_error
+          expect(response).to be_forbidden
         end
       end
 

--- a/spec/requests/file_upload_spec.rb
+++ b/spec/requests/file_upload_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe 'FileUpload API', type: :request do
 
         body = JSON.parse(response.body)
         expect(body['code']).to eql(503)
-        expect(body['name']).to eql('unavailable.file-store-failed')
+        expect(body['name']).to eql('error.file-store-failed')
       end
     end
 


### PR DESCRIPTION
Any errors returned by the uploads controller need to be "understood" by the different validators implemented in the metadata presenter.

If the validator is not trigger for a given error, it is considered "valid" and has the consequence it produces an unhandled error on the runner/frontend instead of a "nice" error like it should.

These are rare errors majority of the time will not happen, but if any of them happen now they will show a generic "nice error" (requires new version of metadata presenter in the runner, separate PRs).