### PR TITLE
Standardise uploads authentication errors

### DIFF
--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -32,7 +32,13 @@ module Concerns
       detail = I18n.t(:detail, scope: [:error_messages, error_code], default: '')
       error[:detail] = detail unless detail.empty?
 
-      render json: { errors: [error] }, status: status
+      # NOTE: upload responses need to conform to a specific format
+      # to be understood by the frontend
+      if is_a?(UploadsController)
+        render json: { code: status, name: "error.#{error_code}" }, status:
+      else
+        render json: { errors: [error] }, status:
+      end
     end
   end
 end

--- a/spec/requests/user_file_spec.rb
+++ b/spec/requests/user_file_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'user filestore API', type: :request do
       end
 
       it 'returns json error message' do
-        expect(json['errors'].first['title']).to eq(I18n.t('error_messages.token_not_valid.title'))
+        expect(json['name']).to eq('error.token_not_valid')
       end
     end
 
@@ -34,7 +34,7 @@ RSpec.describe 'user filestore API', type: :request do
       end
 
       it 'returns json error message' do
-        expect(json['errors'].first['title']).to eq(I18n.t('error_messages.token_not_present.title'))
+        expect(json['name']).to eq('error.token_not_present')
       end
     end
 
@@ -43,12 +43,13 @@ RSpec.describe 'user filestore API', type: :request do
         allow_any_instance_of(UploadsController).to receive(:verify_token!).and_raise(StandardError)
         post "/service/#{service_slug}/user/#{user_identifier}"
       end
+
       it 'returns a 500 status' do
         expect(response).to have_http_status(500)
       end
 
       it 'returns json error message' do
-        expect(json['errors'].first['title']).to eq(I18n.t('error_messages.internal_server_error.title'))
+        expect(json['name']).to eq('error.internal_server_error')
       end
     end
   end


### PR DESCRIPTION
Make these errors that can be raised if something goes wrong with the JWT authentication conform to the format that is expected by the metadata-presenter / runner so we can still present a "nice error" to the user.

This is a follow-up to previous PR #569.