### PR TITLE
Cleanup legacy unused code

### DIFF
--- a/app/controllers/concerns/jwt_authentication.rb
+++ b/app/controllers/concerns/jwt_authentication.rb
@@ -54,16 +54,6 @@ module Concerns
       raise Exceptions::TokenNotValidError
     end
 
-    # TODO: this method seems to not be in use anymore
-    # Legacy FB forms are using v2 token cache too
-    # Confirm to be sure and cleanup code/tests
-    # :nocov:
-    def service_token(service_slug)
-      service = ServiceTokenService.new(service_slug: service_slug)
-      service.get
-    end
-    # :nocov:
-
     def public_key(service_slug)
       service = ServiceTokenService.new(service_slug: service_slug)
       service.public_key

--- a/app/services/adapters/service_token_cache_client.rb
+++ b/app/services/adapters/service_token_cache_client.rb
@@ -8,12 +8,6 @@ module Adapters
       @root_url = params[:root_url] || ENV['SERVICE_TOKEN_CACHE_ROOT_URL']
     end
 
-    def get(service_slug)
-      url = service_token_uri(service_slug)
-      response = Net::HTTP.get_response(url)
-      JSON.parse(response.body).fetch('token') if response.code.to_i == 200
-    end
-
     def public_key_for(service_slug)
       url = public_key_uri(service_slug)
       response = Net::HTTP.get_response(url, headers)
@@ -32,13 +26,6 @@ module Adapters
         'X-Request-Id' => Current.request_id
       }.freeze
     end
-
-    # TODO: this method seems to not be in use anymore
-    # :nocov:
-    def service_token_uri(service_slug)
-      URI.join(@root_url, '/service/', service_slug)
-    end
-    # :nocov:
 
     def public_key_uri(service_slug)
       URI.join(root_url, '/service/v2/', service_slug)

--- a/app/services/service_token_service.rb
+++ b/app/services/service_token_service.rb
@@ -5,10 +5,6 @@ class ServiceTokenService
     @service_slug = service_slug
   end
 
-  def get
-    client.get(service_slug)
-  end
-
   def public_key
     client.public_key_for(service_slug)
   end

--- a/spec/controllers/concerns/jwt_authentication_spec.rb
+++ b/spec/controllers/concerns/jwt_authentication_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe 'Concerns::JWTAuthentication' do
 
   before do
     allow(Adapters::ServiceTokenCacheClient).to receive(:new).and_return(fake_client)
-    allow(fake_client).to receive(:get).with('service-slug').and_return(service_token)
     allow(fake_client).to receive(:public_key_for).with(service_slug).and_return(public_key)
 
     request.headers.merge!(headers)

--- a/spec/controllers/uploads_controller_spec.rb
+++ b/spec/controllers/uploads_controller_spec.rb
@@ -19,8 +19,7 @@ RSpec.describe UploadsController, type: :controller do
   let(:private_key) { OpenSSL::PKey::RSA.new(Base64.strict_decode64(encoded_private_key)) }
   let(:encoded_public_key) { 'LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUEzU1RCMkxnaDAyWWt0K0xxejluNgo5MlNwV0xFdXNUR1hEMGlmWTBuRHpmbXF4MWVlbHoxeHhwSk9MZXRyTGdxbjM3aE1qTlkwL25BQ2NNZHVFSDlLClhycmFieFhYVGwxeVkyMStnbVd4NDlOZVlESW5iZG0rNnM1S3ZMZ1VOTjdYVmNlUDlQdXFaeXN4Q1ZBNFRubUwKRURLZ2xTV2JVeWZ0QmVhVENKVkk2NFoxMmRNdFBiQWd4V0FmZVNMbGI3QlBsc0htL0gwQUFMK25iYU9Da3d2cgpQSkRMVFZPek9XSE1vR2dzMnJ4akJIRC9OV05ac1RWUWFvNFh3aGVidWRobHZNaWtFVzMyV0tnS3VISFc4emR2ClU4TWozM1RYK1picVhPaWtkRE54dHd2a1hGN0xBM1loOExJNUd5ZDlwNmYyN01mbGRnVUlIU3hjSnB5MUo4QVAKcXdJREFRQUIKLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg==' }
   let(:public_key) { OpenSSL::PKey::RSA.new(Base64.strict_decode64(encoded_public_key)) }
-  let(:fake_service) { double(:service, get: 'service-token') }
-  let(:fake_service_with_no_token) { double(:service) }
+  let(:fake_service) { double(:service) }
 
   before do
     allow(ServiceTokenService).to receive(:new).with(service_slug: '').and_return(fake_service)

--- a/spec/requests/file_download_spec.rb
+++ b/spec/requests/file_download_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe 'GET /service/{service_slug}/user/{user_id}/{fingerprint}', type:
 
   before :each do
     allow(ServiceTokenService).to receive(:new).with(service_slug: 'service-slug').and_return(fake_service)
-    allow(fake_service).to receive(:get).and_return('service-token')
     allow(fake_service).to receive(:public_key).and_return(public_key)
     allow(Aws::S3::Client).to receive(:new).and_return(s3)
   end

--- a/spec/requests/file_upload_spec.rb
+++ b/spec/requests/file_upload_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe 'FileUpload API', type: :request do
   before :each do
     disable_malware_scanner!
     allow(ServiceTokenService).to receive(:new).with(service_slug: 'service-slug').and_return(fake_service)
-    allow(fake_service).to receive(:get).and_return('service-token')
     allow(fake_service).to receive(:public_key).and_return(public_key)
     allow(Aws::S3::Client).to receive(:new).and_return(s3)
   end

--- a/spec/services/adapters/service_token_cache_client_spec.rb
+++ b/spec/services/adapters/service_token_cache_client_spec.rb
@@ -23,53 +23,6 @@ RSpec.describe Adapters::ServiceTokenCacheClient do
 
   subject { described_class.new(root_url: 'http://www.example.com') }
 
-  describe '#get' do
-    let(:service_slug) { 'my-service' }
-    let(:response_code) { '200' }
-    let(:mock_response) { double('response', body: '{"token": "token value"}', code: response_code) }
-
-    before do
-      allow(subject).to receive(:service_token_uri).with(service_slug).and_return('http://service/token/url')
-      allow(Net::HTTP).to receive(:get_response).and_return(mock_response)
-    end
-
-    it 'gets the service_token_uri for the given service_slug' do
-      expect(subject).to receive(:service_token_uri).with(service_slug).and_return('http://service/token/url')
-      subject.get(service_slug)
-    end
-
-    it 'makes a GET request to the service_token_uri' do
-      expect(Net::HTTP).to receive(:get_response).with('http://service/token/url').and_return(mock_response)
-      subject.get(service_slug)
-    end
-
-    context 'when the response has code 200' do
-      let(:response_code) { '200' }
-
-      it 'returns the token key from the body' do
-        expect(subject.get(service_slug)).to eq('token value')
-      end
-    end
-
-    context 'when the response code is not 200' do
-      let(:response_code) { '418' }
-
-      it 'returns nil' do
-        expect(subject.get(service_slug)).to be_nil
-      end
-    end
-
-    context 'when an error is raised' do
-      before do
-        allow(JSON).to receive(:parse).and_raise(JSON::ParserError)
-      end
-
-      it 'allows the error to pass out uncaught' do
-        expect{subject.get(service_slug)}.to raise_error(JSON::ParserError)
-      end
-    end
-  end
-
   describe '#public_key_for' do
     let(:service_slug) { 'my-service' }
     let(:encoded_public_key) do

--- a/spec/services/file_manager_spec.rb
+++ b/spec/services/file_manager_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe FileManager do
   let(:file) { file_fixture('hello_world.txt') }
   let(:encoded_file) { Base64.strict_encode64(file.read) }
   let(:user_id) { SecureRandom.uuid }
-  let(:service_token) { SecureRandom.hex }
   let(:service_slug) { 'service-slug' }
   let(:encrypted_user_id_and_token) { SecureRandom.hex(16) }
   let(:bucket) { ENV['AWS_S3_BUCKET_NAME'] }

--- a/spec/services/service_token_service_spec.rb
+++ b/spec/services/service_token_service_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe ServiceTokenService do
 
   subject { described_class.new(service_slug: service_slug) }
 
-  describe '#get' do
+  describe '#public_key' do
     it 'delegates call to client' do
       allow(Adapters::ServiceTokenCacheClient).to receive(:new).and_return(fake_client)
-      expect(fake_client).to receive(:get).with(service_slug).and_return(service_slug)
+      expect(fake_client).to receive(:public_key_for).with(service_slug).and_return(service_slug)
 
-      expect(subject.get).to eql(service_slug)
+      expect(subject.public_key).to eql(service_slug)
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/hVMnTnAG

Remove no longer used legacy code, pertaining mostly to the service token cache requests. Legacy forms were already using v2 cache anyways.