### PR TITLE
CDPTKAN-415: Dockerize fb-user-filestore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ config/clamd/*.conf
 node_modules
 package-lock.json
 .env.local
+/volume

--- a/Makefile
+++ b/Makefile
@@ -59,5 +59,8 @@ build: stop
 serve: stop build
 	$(DOCKER_COMPOSE) up
 
+setup: stop build
+	$(DOCKER_COMPOSE) up -d
+
 spec: build
 	$(DOCKER_COMPOSE) run --rm app bundle exec rspec --require spec_helper

--- a/Makefile
+++ b/Makefile
@@ -63,4 +63,4 @@ setup: stop build
 	$(DOCKER_COMPOSE) up -d
 
 spec: build
-	$(DOCKER_COMPOSE) run --rm app bundle exec rspec --require spec_helper
+	$(DOCKER_COMPOSE) run --rm api env RAILS_ENV=test bundle exec rspec --require spec_helper

--- a/README.md
+++ b/README.md
@@ -44,3 +44,16 @@ hash = JSON.parse(response)
 
 File.open('/tmp/out', 'wb') {|f| f.write Base64.strict_decode64(hash['file']) }
 ```
+
+## Troubleshooting
+
+### Error: "The specified bucket does not exist"
+```shell
+user-filestore-api  | [UploadsController] Unexpected error: The specified bucket does not exist
+user-filestore-api  | Completed 503 Service Unavailable in 437ms (Views: 0.3ms | Allocations: 163352)
+```
+### Solution: 
+Execute the following command from `localstack-main` container
+```shell 
+docker exec -it localstack-main /bin/sh  -c "awslocal s3api create-bucket --bucket moj-formbuilder"
+```

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,6 +1,12 @@
 if Rails.env.development?
+  # Prefer an explicit endpoint via ENV to support running inside/outside Docker seamlessly.
+  # Default to the Docker Compose service name ("localstack") so the API container
+  # can reach LocalStack over the Docker network. If you run the app on the host
+  # (not in Docker), set AWS_ENDPOINT to "http://localhost.localstack.cloud:4566".
+  endpoint = ENV['AWS_ENDPOINT'] || 'http://localstack:4566'
+
   Aws.config.update(
-    endpoint: 'http://localstack:4572',
+    endpoint: endpoint,
     credentials: Aws::Credentials.new('qwerty', 'qwerty'),
     region: 'us-east-1',
     force_path_style: true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,6 @@ services:
       KEY_ENCRYPTION_IV: 1234567890123456
       ENCRYPTION_IV: 1234567890123451
       ENCRYPTION_KEY: a9c12000de36def805e4c2107bd8e910
-      LOCALSTACK_DOCKER_NAME: ripan
     networks:
       - app-net
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,42 @@
-version: '3.4'
+networks:
+  app-net:
+    name: fb-app-bridge-network
 
 services:
-  app:
+  api:
+    container_name: user-filestore-api
     build:
       context: .
       dockerfile: ./Dockerfile
     ports:
       - '3000:3000'
     environment:
+      # Keys below are all fake and can be committed to git
       SECRET_KEY_BASE: 'super_secret'
       MAX_IAT_SKEW_SECONDS: "300"
+      RAILS_ENV: development
+      RAILS_LOG_TO_STDOUT: "true"
+      SERVICE_TOKEN_CACHE_ROOT_URL: http://runner-service-token-cache-api:3000
+      RAILS_DEVELOPMENT_HOSTS: user-filestore-api
+      AWS_S3_BUCKET_NAME: moj-formbuilder
+      KEY_ENCRYPTION_IV: 1234567890123456
+      ENCRYPTION_IV: 1234567890123451
+      ENCRYPTION_KEY: a9c12000de36def805e4c2107bd8e910
+      LOCALSTACK_DOCKER_NAME: ripan
+    networks:
+      - app-net
+
+  localstack:
+    container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"
+    image: localstack/localstack
+    ports:
+      - "127.0.0.1:4566:4566"            # LocalStack Gateway
+      - "127.0.0.1:4510-4559:4510-4559"  # external services port range
+    environment:
+      # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
+      - DEBUG=${DEBUG:-0}
+    networks:
+      - app-net
+    volumes:
+      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"


### PR DESCRIPTION
### Update Docker setup and AWS config for local development

- Adds /volume to .gitignore and updates docker-compose.yml to use a custom network, renames the app service to api, and adds a [localstack](https://hub.docker.com/r/localstack/localstack) service with persistent volume. 

- The Makefile gains a 'setup' target for easier environment initialization. AWS initializer now prefers an explicit endpoint via ENV for better compatibility inside and outside Docker.

- Group containers into functional networks
-- app-net
- Rename Services to use the convention (api for Backend API)
- Spin up the following services on make setup
  <img width="734" height="173" alt="Screenshot 2025-11-26 at 18 43 33" src="https://github.com/user-attachments/assets/175d4659-dffa-4e4c-b6c6-019a8bac62a1" />

