### PR TITLE
CDPTKAN-462: Fix mime_type for the single column CSV

### DIFF
--- a/app/services/file_manager.rb
+++ b/app/services/file_manager.rb
@@ -138,11 +138,7 @@ class FileManager
 
     # Check if every row matches the header length
     header_size = csv_table.headers.compact.size
-    csv_table.each do |row|
-      return false if row.size != header_size
-    end
-
-    true
+    csv_table.all? { |row| row.size == header_size }
   rescue CSV::MalformedCSVError
     # If the file is not a valid CSV (e.g., mismatched quotes),
     # it raises an error and we return false.

--- a/app/services/file_manager.rb
+++ b/app/services/file_manager.rb
@@ -1,5 +1,6 @@
 require 'securerandom'
 require 'digest'
+require 'csv'
 
 class FileManager
   attr_reader :file
@@ -45,7 +46,14 @@ class FileManager
   end
 
   def mime_type
-    @mime_type ||= `file --b --mime-type '#{path_to_file}'`.strip
+    @mime_type ||= begin
+      type = `file --b --mime-type '#{path_to_file}'`.strip
+      if type == 'text/plain' && csv?
+        'text/csv'
+      else
+        type
+      end
+    end
   end
 
   def upload
@@ -119,6 +127,26 @@ class FileManager
 
   def ensure_quarantine_folder_exists
     FileUtils.mkdir_p(quarantine_folder)
+  end
+
+  def csv?
+    contents = File.read(path_to_file)
+    csv_table = CSV.parse(contents, headers: true)
+
+    # Ensure there is at least one row
+    return false if csv_table.empty?
+
+    # Check if every row matches the header length
+    header_size = csv_table.headers.compact.size
+    csv_table.each do |row|
+      return false if row.size != header_size
+    end
+
+    true
+  rescue CSV::MalformedCSVError
+    # If the file is not a valid CSV (e.g., mismatched quotes),
+    # it raises an error and we return false.
+    false
   end
 
   def quarantine_folder

--- a/app/services/file_manager.rb
+++ b/app/services/file_manager.rb
@@ -45,10 +45,14 @@ class FileManager
     MimeChecker.new(mime_type, allowed_types).call
   end
 
+  # linux 'file' command (via libmagic) ignores the filename and extension. It looks only at the bytes inside the file and tries to match known signatures.
+  # So if single-column CSV has plain ASCII text, no commas, no quotes, no consistent delimiter pattern it returns mime-type as `text/plain`
+  # Email server checks the mime-type and converts single-column csv to a text file when sent as an attachment
+  # So we have to explicitly set mime-type as `text/csv` for a single-column CSV and check if it has a valid CSV format
   def mime_type
     @mime_type ||= begin
       type = `file --b --mime-type '#{path_to_file}'`.strip
-      if type == 'text/plain' && csv?
+      if type == 'text/plain' && valid_csv?
         'text/csv'
       else
         type
@@ -129,15 +133,17 @@ class FileManager
     FileUtils.mkdir_p(quarantine_folder)
   end
 
-  def csv?
+  def valid_csv?
     contents = File.read(path_to_file)
     csv_table = CSV.parse(contents, headers: true)
 
-    # Ensure there is at least one row
     return false if csv_table.empty?
 
     # Check if every row matches the header length
     header_size = csv_table.headers.compact.size
+
+    return false if header_size < 1
+
     csv_table.all? { |row| row.size == header_size }
   rescue CSV::MalformedCSVError
     # If the file is not a valid CSV (e.g., mismatched quotes),

--- a/spec/services/file_manager_spec.rb
+++ b/spec/services/file_manager_spec.rb
@@ -123,6 +123,65 @@ RSpec.describe FileManager do
     end
   end
 
+  describe '#mime_type' do
+    before :each do
+      subject.save_to_disk
+    end
+
+    context 'when it is a multi-column CSV' do
+      let(:encoded_file) { Base64.strict_encode64("header1,header2\nvalue1,value2") }
+
+      it 'returns text/csv' do
+        expect(subject.mime_type).to eq('text/csv')
+      end
+    end
+
+    context 'when it is a single-column CSV' do
+      let(:encoded_file) { Base64.strict_encode64("header\nvalue1\nvalue2") }
+
+      it 'returns text/csv' do
+        expect(subject.mime_type).to eq('text/csv')
+      end
+    end
+
+    context 'when it is an empty CSV (headers only)' do
+      let(:encoded_file) { Base64.strict_encode64("header1,header2\n") }
+      it 'returns text/plain (not recognized as CSV)' do
+        expect(subject.mime_type).to eq('text/plain')
+      end
+    end
+
+    context 'when row lengths are inconsistent' do
+      let(:encoded_file) { Base64.strict_encode64("header1,header2\nvalue1,value2,value3") }
+      it 'returns text/plain (not recognized as CSV)' do
+        expect(subject.mime_type).to eq('text/plain')
+      end
+    end
+
+    context 'when it is plain text' do
+      let(:encoded_file) { Base64.strict_encode64("This is just some text.") }
+
+      it 'returns text/plain' do
+        expect(subject.mime_type).to eq('text/plain')
+      end
+    end
+
+    context 'when it is a malformed CSV (mismatched quotes)' do
+      let(:encoded_file) { Base64.strict_encode64("header1,header2\n\"value1\"value2,value3") }
+      it 'returns text/plain' do
+        expect(subject.mime_type).to eq('text/plain')
+      end
+    end
+
+    context 'when it is a malformed CSV' do
+      let(:encoded_file) { Base64.strict_encode64("header1,header2\n\"value1\"value2") }
+
+      it 'returns text/plain' do
+        expect(subject.mime_type).to eq('text/plain')
+      end
+    end
+  end
+
   describe '#has_virus?' do
     context 'when file has a virus' do
       it 'returns true' do

--- a/spec/services/file_manager_spec.rb
+++ b/spec/services/file_manager_spec.rb
@@ -172,14 +172,6 @@ RSpec.describe FileManager do
         expect(subject.mime_type).to eq('text/plain')
       end
     end
-
-    context 'when it is a malformed CSV' do
-      let(:encoded_file) { Base64.strict_encode64("header1,header2\n\"value1\"value2") }
-
-      it 'returns text/plain' do
-        expect(subject.mime_type).to eq('text/plain')
-      end
-    end
   end
 
   describe '#has_virus?' do


### PR DESCRIPTION
### Issue: 
The issue where single-column CSV files were being converted to text in emails was caused by the `file` command misidentifying them as `text/plain`. 
Since CSV files lack a standard header, the `file` command often defaults to `text/plain`, especially when the CSV has only one column or simple content.

### Solution:
Implemented a fallback check in `FileManager#mime_type`: if `file` returns `text/plain`, check if the content looks like CSV.


```ruby
### submitter-api
submission = Submission.find(submission_id
decrypted_submission = submission.decrypted_submission.merge('submission_id' => submission.id)
payload_service = V2::SubmissionPayloadService.new(decrypted_submission)
```

Before
<img width="1366" height="115" alt="Screenshot 2026-02-06 at 09 33 41" src="https://github.com/user-attachments/assets/8359bc7c-17fe-45f0-9722-3ab1fde601cb" />

After
<img width="1364" height="114" alt="Screenshot 2026-02-06 at 09 33 50" src="https://github.com/user-attachments/assets/6811a511-1d37-4d2b-8a9c-8651045f5925" />
